### PR TITLE
Improve Code Quality 5

### DIFF
--- a/Src/Fido2/AttestationFormat/Apple.cs
+++ b/Src/Fido2/AttestationFormat/Apple.cs
@@ -50,9 +50,12 @@ namespace Fido2NetLib
             // 2. Verify x5c is a valid certificate chain starting from the credCert to the Apple WebAuthn root certificate.
             // This happens in AuthenticatorAttestationResponse.VerifyAsync using metadata from MDS3
 
-            var trustPath = x5cArray.Values
-                .Select(x => new X509Certificate2((byte[])x))
-                .ToArray();
+            var trustPath = new X509Certificate2[x5cArray.Length];
+
+            for (int i = 0; i < trustPath.Length; i++)
+            {
+                trustPath[i] = new X509Certificate2((byte[])x5cArray[i]);
+            }
 
             // credCert is the first certificate in the trust path
             var credCert = trustPath[0];
@@ -72,7 +75,7 @@ namespace Fido2NetLib
 
             // 6. Verify credential public key matches the Subject Public Key of credCert.
             // First, obtain COSE algorithm being used from credential public key
-            var coseAlg = (int)CredentialPublicKey[COSE.KeyCommonParameter.Alg];
+            var coseAlg = (COSE.Algorithm)(int)CredentialPublicKey[COSE.KeyCommonParameter.Alg];
 
             // Next, build temporary CredentialPublicKey for comparison from credCert and COSE algorithm
             var cpk = new CredentialPublicKey(credCert, coseAlg);

--- a/Src/Fido2/AttestationFormat/AttestationFormat.cs
+++ b/Src/Fido2/AttestationFormat/AttestationFormat.cs
@@ -26,7 +26,7 @@ namespace Fido2NetLib
         {
             byte[] aaguid = null;
             var ext = exts.Cast<X509Extension>().FirstOrDefault(e => e.Oid.Value is "1.3.6.1.4.1.45724.1.1.4"); // id-fido-gen-ce-aaguid
-            if (null != ext)
+            if (ext != null)
             {
                 var decodedAaguid = Asn1Element.Decode(ext.RawData);
                 decodedAaguid.CheckTag(Asn1Tag.PrimitiveOctetString);
@@ -39,6 +39,7 @@ namespace Fido2NetLib
 
             return aaguid;
         }
+
         internal static bool IsAttnCertCACert(X509ExtensionCollection exts)
         {
             var ext = exts.Cast<X509Extension>().FirstOrDefault(e => e.Oid.Value is "2.5.29.19");
@@ -49,6 +50,7 @@ namespace Fido2NetLib
 
             return true;
         }
+
         internal static byte U2FTransportsFromAttnCert(X509ExtensionCollection exts)
         {
             var u2ftransports = new byte();
@@ -73,6 +75,7 @@ namespace Fido2NetLib
 
             return u2ftransports;
         }
+
         public virtual (AttestationType, X509Certificate2[]) Verify(CborMap attStmt, byte[] authenticatorData, byte[] clientDataHash)
         {
             this.attStmt = attStmt;

--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -90,9 +89,8 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException("Invalid fido-u2f attestation signature");
 
             // 7. Optionally, inspect x5c and consult externally provided knowledge to determine whether attStmt conveys a Basic or AttCA attestation
-            var trustPath = ((CborArray)X5c).Values
-                .Select(x => new X509Certificate2((byte[])x))
-                .ToArray();
+
+            var trustPath = new X509Certificate2[1] { attCert };
 
             return (AttestationType.AttCa, trustPath);
         }

--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -19,10 +19,13 @@ namespace Fido2NetLib
         {
         }
 
-        public AuthenticatorAssertionRawResponse Raw { get; set; }
-        public byte[] AuthenticatorData { get; set; }
-        public byte[] Signature { get; set; }
-        public byte[] UserHandle { get; set; }
+        public AuthenticatorAssertionRawResponse Raw { get; init; }
+
+        public byte[] AuthenticatorData { get; init; }
+
+        public byte[] Signature { get; init; }
+
+        public byte[] UserHandle { get; init; }
 
         public static AuthenticatorAssertionResponse Parse(AuthenticatorAssertionRawResponse rawResponse)
         {
@@ -118,9 +121,7 @@ namespace Fido2NetLib
             // If true, the AppID was used and thus, when verifying an assertion, the Relying Party MUST expect the rpIdHash to be the hash of the AppID, not the RP ID.
             var rpid = Raw.Extensions?.AppID ?? false ? options.Extensions?.AppID : options.RpId;
             byte[] hashedRpId = SHA256.HashData(Encoding.UTF8.GetBytes(rpid ?? string.Empty));
-            // 15
-            byte[] hashedClientDataJson = SHA256.HashData(Raw.Response.ClientDataJson);
-            
+            byte[] hashedClientDataJson = SHA256.HashData(Raw.Response.ClientDataJson);            
 
             if (!authData.RpIdHash.SequenceEqual(hashedRpId))
                 throw new Fido2VerificationException("Hash mismatch RPID");

--- a/Src/Fido2/Cbor/CborObject.cs
+++ b/Src/Fido2/Cbor/CborObject.cs
@@ -77,9 +77,11 @@ namespace Fido2NetLib.Cbor
 
         private static CborArray ReadArray(CborReader reader)
         {
-            var items = new List<CborObject>();
-
             int? count = reader.ReadStartArray();
+
+            var items = count != null
+                ? new List<CborObject>(count.Value)
+                : new List<CborObject>();
 
             while (!(reader.PeekState() is CborReaderState.EndArray or CborReaderState.Finished))
             {

--- a/Src/Fido2/DateTimeHelper.cs
+++ b/Src/Fido2/DateTimeHelper.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Fido2NetLib
-{
-   internal static class DateTimeHelper
-    {
-        internal static DateTime UnixEpoch { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-    }
-}

--- a/Src/Fido2/Extensions/DataHelper.cs
+++ b/Src/Fido2/Extensions/DataHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace Fido2NetLib
 {

--- a/Src/Fido2/Objects/AttestedCredentialData.cs
+++ b/Src/Fido2/Objects/AttestedCredentialData.cs
@@ -16,60 +16,6 @@ namespace Fido2NetLib.Objects
         private readonly int _minLength = Marshal.SizeOf(typeof(Guid)) + sizeof(ushort) + sizeof(byte) + sizeof(byte);
 
         /// <summary>
-        /// The AAGUID of the authenticator. Can be used to identify the make and model of the authenticator.
-        /// <see cref="https://www.w3.org/TR/webauthn/#aaguid"/>
-        /// </summary>
-        public Guid AaGuid { get; private set; }
-
-        /// <summary>
-        /// A probabilistically-unique byte sequence identifying a public key credential source and its authentication assertions.
-        /// <see cref="https://www.w3.org/TR/webauthn/#credential-id"/>
-        /// </summary>
-        public byte[] CredentialID { get; private set; }
-
-        /// <summary>
-        /// The credential public key encoded in COSE_Key format, as defined in 
-        /// Section 7 of RFC8152, using the CTAP2 canonical CBOR encoding form.
-        /// <see cref="https://www.w3.org/TR/webauthn/#credential-public-key"/>
-        /// </summary>
-        public CredentialPublicKey CredentialPublicKey { get; private set; }
-
-        internal static void SwapBytes(byte[] bytes, int index1, int index2)
-        {
-            var temp = bytes[index1];
-            bytes[index1] = bytes[index2];
-            bytes[index2] = temp;
-        }
-
-        /// <summary>
-        /// AAGUID is sent as big endian byte array, this converter is for little endian systems.
-        /// </summary>
-        public static Guid FromBigEndian(byte[] Aaguid)
-        {
-            SwapBytes(Aaguid, 0, 3);
-            SwapBytes(Aaguid, 1, 2);
-            SwapBytes(Aaguid, 4, 5);
-            SwapBytes(Aaguid, 6, 7);
-
-            return new Guid(Aaguid);
-        }
-
-        /// <summary>
-        /// AAGUID is sent as big endian byte array, this converter is for little endian systems.
-        /// </summary>
-        public static byte[] AaGuidToBigEndian(Guid AaGuid)
-        {
-            var aaguid = AaGuid.ToByteArray();
-
-            SwapBytes(aaguid, 0, 3);
-            SwapBytes(aaguid, 1, 2);
-            SwapBytes(aaguid, 4, 5);
-            SwapBytes(aaguid, 6, 7);
-
-            return aaguid;
-        }
-
-        /// <summary>
         /// Instantiates an AttestedCredentialData object from an aaguid, credentialID, and CredentialPublicKey
         /// </summary>
         /// <param name="aaguid"></param>
@@ -81,7 +27,6 @@ namespace Fido2NetLib.Objects
             CredentialID = credentialID;
             CredentialPublicKey = cpk;
         }
-
 
         /// <summary>
         /// Decodes attested credential data.
@@ -136,6 +81,60 @@ namespace Fido2NetLib.Objects
             bytesRead = position;
         }
 
+        /// <summary>
+        /// The AAGUID of the authenticator. Can be used to identify the make and model of the authenticator.
+        /// <see cref="https://www.w3.org/TR/webauthn/#aaguid"/>
+        /// </summary>
+        public Guid AaGuid { get; private set; }
+
+        /// <summary>
+        /// A probabilistically-unique byte sequence identifying a public key credential source and its authentication assertions.
+        /// <see cref="https://www.w3.org/TR/webauthn/#credential-id"/>
+        /// </summary>
+        public byte[] CredentialID { get; private set; }
+
+        /// <summary>
+        /// The credential public key encoded in COSE_Key format, as defined in 
+        /// Section 7 of RFC8152, using the CTAP2 canonical CBOR encoding form.
+        /// <see cref="https://www.w3.org/TR/webauthn/#credential-public-key"/>
+        /// </summary>
+        public CredentialPublicKey CredentialPublicKey { get; private set; }
+
+        internal static void SwapBytes(byte[] bytes, int index1, int index2)
+        {
+            var temp = bytes[index1];
+            bytes[index1] = bytes[index2];
+            bytes[index2] = temp;
+        }
+
+        /// <summary>
+        /// AAGUID is sent as big endian byte array, this converter is for little endian systems.
+        /// </summary>
+        public static Guid FromBigEndian(byte[] Aaguid)
+        {
+            SwapBytes(Aaguid, 0, 3);
+            SwapBytes(Aaguid, 1, 2);
+            SwapBytes(Aaguid, 4, 5);
+            SwapBytes(Aaguid, 6, 7);
+
+            return new Guid(Aaguid);
+        }
+
+        /// <summary>
+        /// AAGUID is sent as big endian byte array, this converter is for little endian systems.
+        /// </summary>
+        public static byte[] AaGuidToBigEndian(Guid AaGuid)
+        {
+            var aaguid = AaGuid.ToByteArray();
+
+            SwapBytes(aaguid, 0, 3);
+            SwapBytes(aaguid, 1, 2);
+            SwapBytes(aaguid, 4, 5);
+            SwapBytes(aaguid, 6, 7);
+
+            return aaguid;
+        }
+
         public override string ToString()
         {
             return $"AAGUID: {AaGuid}, CredentialID: {Convert.ToHexString(CredentialID)}, CredentialPublicKey: {CredentialPublicKey}";
@@ -143,31 +142,29 @@ namespace Fido2NetLib.Objects
 
         public byte[] ToByteArray()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var writer = new BinaryWriter(ms))
             {
-                using (var writer = new BinaryWriter(ms))
+                // Write the aaguid bytes out, reverse if we're on a little endian system
+                if (BitConverter.IsLittleEndian)
                 {
-                    // Write the aaguid bytes out, reverse if we're on a little endian system
-                    if (BitConverter.IsLittleEndian)
-                    {
-                        writer.Write(AaGuidToBigEndian(AaGuid));
-                    }
-                    else
-                    {
-                        writer.Write(AaGuid.ToByteArray());
-                    }
-
-                    // Write the length of credential ID, as big endian bytes of a 16-bit unsigned integer
-                    writer.WriteUInt16BigEndian((ushort)CredentialID.Length);
-                    
-                    // Write CredentialID bytes
-                    writer.Write(CredentialID);
-
-                    // Write credential public key bytes
-                    writer.Write(CredentialPublicKey.GetBytes());
+                    writer.Write(AaGuidToBigEndian(AaGuid));
                 }
-                return ms.ToArray();
+                else
+                {
+                    writer.Write(AaGuid.ToByteArray());
+                }
+
+                // Write the length of credential ID, as big endian bytes of a 16-bit unsigned integer
+                writer.WriteUInt16BigEndian((ushort)CredentialID.Length);
+
+                // Write CredentialID bytes
+                writer.Write(CredentialID);
+
+                // Write credential public key bytes
+                writer.Write(CredentialPublicKey.GetBytes());
             }
+            return ms.ToArray();
         }
     }
 }

--- a/Src/Fido2/Objects/CredentialIdUserHandleParams.cs
+++ b/Src/Fido2/Objects/CredentialIdUserHandleParams.cs
@@ -4,14 +4,15 @@
     /// Paramters used for callback function
     /// </summary>
     public sealed class IsUserHandleOwnerOfCredentialIdParams
-    {
-        public byte[] UserHandle { get; }
-        public byte[] CredentialId { get; }
-
+    {   
         public IsUserHandleOwnerOfCredentialIdParams(byte[] credentialId, byte[] userHandle)
         {
             CredentialId = credentialId;
             UserHandle = userHandle;
         }
+
+        public byte[] UserHandle { get; }
+
+        public byte[] CredentialId { get; }
     }
 }

--- a/Src/Fido2/Objects/CredentialIdUserParams.cs
+++ b/Src/Fido2/Objects/CredentialIdUserParams.cs
@@ -5,13 +5,14 @@
     /// </summary>
     public sealed class IsCredentialIdUniqueToUserParams
     {
-        public byte[] CredentialId { get; set; }
-        public Fido2User User { get; set; }
-
         public IsCredentialIdUniqueToUserParams(byte[] credentialId, Fido2User user)
         {
             CredentialId = credentialId;
             User = user;
         }
+
+        public byte[] CredentialId { get; }
+
+        public Fido2User User { get; }
     }
 }

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -63,11 +63,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -165,10 +165,10 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.N, rsaparams.Modulus },
-                        { (int)COSE.KeyTypeParameter.E, rsaparams.Exponent }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.N, rsaparams.Modulus },
+                        { COSE.KeyTypeParameter.E, rsaparams.Exponent }
                     };
 
                     _credentialPublicKey = new CredentialPublicKey(cpk);
@@ -398,11 +398,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -485,11 +485,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -572,11 +572,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -658,11 +658,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -744,11 +744,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -832,11 +832,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -919,11 +919,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -1006,11 +1006,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];
@@ -1092,11 +1092,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -77,7 +77,7 @@ namespace Test.Attestation
 
                     var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
 
-                    List<Claim> claims = new List<Claim>
+                    var claims = new List<Claim>
                     {
                         new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
                         new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
@@ -443,7 +443,7 @@ namespace Test.Attestation
                 }
             }
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
-            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+            Assert.StartsWith("SafetyNet timestampMs must be between one minute ago and now, got:", ex.Result.Message);
         }
 
         [Fact]
@@ -499,7 +499,7 @@ namespace Test.Attestation
 
                     var attToBeSigned = _attToBeSignedHash(HashAlgorithmName.SHA256);
 
-                    List<Claim> claims = new List<Claim>
+                    var claims = new List<Claim>
                     {
                         new Claim("nonce", Convert.ToBase64String(attToBeSigned) , ClaimValueTypes.String),
                         new Claim("ctsProfileMatch", bool.TrueString, ClaimValueTypes.Boolean),
@@ -530,7 +530,7 @@ namespace Test.Attestation
                 }
             }
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
-            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+            Assert.StartsWith("SafetyNet timestampMs must be between one minute ago and now, got:", ex.Result.Message);
         }
 
         [Fact]
@@ -616,7 +616,7 @@ namespace Test.Attestation
                 }
             }
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => MakeAttestationResponse());
-            Assert.StartsWith("SafetyNet timestampMs must be present and between one minute ago and now, got:", ex.Result.Message);
+            Assert.Equal("SafetyNet timestampMs not found SafetyNet attestation", ex.Result.Message);
         }
 
         [Fact]

--- a/Test/Attestation/Apple.cs
+++ b/Test/Attestation/Apple.cs
@@ -60,11 +60,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)crv }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, crv }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -251,13 +251,7 @@ namespace Test.Attestation
 
                                 var rsaparams = rsaAtt.ExportParameters(true);
 
-                                var cpk = new CborMap();
-                                cpk.Add((int)COSE.KeyCommonParameter.KeyType, (int)type);
-                                cpk.Add((int)COSE.KeyCommonParameter.Alg, (int)alg);
-                                cpk.Add((int)COSE.KeyTypeParameter.N, rsaparams.Modulus);
-                                cpk.Add((int)COSE.KeyTypeParameter.E, rsaparams.Exponent);
-
-                                _credentialPublicKey = new CredentialPublicKey(cpk);
+                                _credentialPublicKey = GetRSACredentialPublicKey(type, alg, rsaparams);
 
                                 unique = rsaparams.Modulus;
                                 exponent = rsaparams.Exponent;
@@ -1699,11 +1693,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = ((byte[])cpk[COSE.KeyTypeParameter.X]).Reverse().ToArray();
@@ -1824,11 +1818,11 @@ namespace Test.Attestation
 
                     var cpk = new CborMap
                     {
-                        { (int)COSE.KeyCommonParameter.KeyType, (int)type },
-                        { (int)COSE.KeyCommonParameter.Alg, (int)alg },
-                        { (int)COSE.KeyTypeParameter.X, ecparams.Q.X },
-                        { (int)COSE.KeyTypeParameter.Y, ecparams.Q.Y },
-                        { (int)COSE.KeyTypeParameter.Crv, (int)curve }
+                        { COSE.KeyCommonParameter.KeyType, type },
+                        { COSE.KeyCommonParameter.Alg, alg },
+                        { COSE.KeyTypeParameter.X, ecparams.Q.X },
+                        { COSE.KeyTypeParameter.Y, ecparams.Q.Y },
+                        { COSE.KeyTypeParameter.Crv, curve }
                     };
 
                     var x = (byte[])cpk[COSE.KeyTypeParameter.X];

--- a/Test/ExistingU2fRegistrationDataTests.cs
+++ b/Test/ExistingU2fRegistrationDataTests.cs
@@ -83,13 +83,13 @@ namespace fido2_net_lib.Test
 
             var coseKey = new CborMap
             {
-                { (int)COSE.KeyCommonParameter.KeyType, (int)COSE.KeyType.EC2 },
+                { COSE.KeyCommonParameter.KeyType, COSE.KeyType.EC2 },
                 { (int)COSE.KeyCommonParameter.Alg, -7 },
 
-                { (int)COSE.KeyTypeParameter.Crv, (int)COSE.EllipticCurve.P256 },
+                { COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.P256 },
 
-                { (int)COSE.KeyTypeParameter.X, point.X },
-                { (int)COSE.KeyTypeParameter.Y, point.Y }
+                { COSE.KeyTypeParameter.X, point.X },
+                { COSE.KeyTypeParameter.Y, point.Y }
             };
 
             return coseKey;

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -186,12 +186,8 @@ namespace fido2_net_lib.Test
                 idFidoGenCeAaguidExt = new X509Extension(oidIdFidoGenCeAaguid, _asnEncodedAaguid, false);
             }
 
-            public async Task<Fido2.CredentialMakeResult> MakeAttestationResponse(CborMap? attestationObject = null)
+            public async Task<Fido2.CredentialMakeResult> MakeAttestationResponse()
             {
-                if (attestationObject is not null)
-                {
-                }
-
                 _attestationObject.Set("authData", new CborByteString(_authData));
 
                 var attestationResponse = new AuthenticatorAttestationRawResponse
@@ -268,7 +264,7 @@ namespace fido2_net_lib.Test
                 ECDsa ecdsa = null;
                 RSA rsa = null;
                 Key privateKey = null;
-                byte[] expandedPrivateKey = null, publicKey = null;
+                byte[] expandedPrivateKey, publicKey = null;
 
                 switch (kty)
                 {

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -1028,21 +1028,22 @@ namespace fido2_net_lib.Test
         {
             var cpk = new CborMap();
 
-            cpk.Add((int)COSE.KeyCommonParameter.KeyType, (int)kty);
-            cpk.Add((int)COSE.KeyCommonParameter.Alg, (int)alg);
+            cpk.Add(COSE.KeyCommonParameter.KeyType, kty);
+            cpk.Add(COSE.KeyCommonParameter.Alg, alg);
+
             switch (kty)
             {
                 case COSE.KeyType.EC2:
-                    cpk.Add((int)COSE.KeyTypeParameter.X, x);
-                    cpk.Add((int)COSE.KeyTypeParameter.Y, y);
+                    cpk.Add(COSE.KeyTypeParameter.X, x);
+                    cpk.Add(COSE.KeyTypeParameter.Y, y);
                     cpk.Add((int)COSE.KeyTypeParameter.Crv, (int)crv);
                     break;
                 case COSE.KeyType.RSA:
-                    cpk.Add((int)COSE.KeyTypeParameter.N, n);
-                    cpk.Add((int)COSE.KeyTypeParameter.E, e);
+                    cpk.Add(COSE.KeyTypeParameter.N, n);
+                    cpk.Add(COSE.KeyTypeParameter.E, e);
                     break;
                 case COSE.KeyType.OKP:
-                    cpk.Add((int)COSE.KeyTypeParameter.X, x);
+                    cpk.Add(COSE.KeyTypeParameter.X, x);
                     cpk.Add((int)COSE.KeyTypeParameter.Crv, (int)crv);
                     break;
                 default:
@@ -1074,7 +1075,7 @@ namespace fido2_net_lib.Test
                     }
                 case COSE.KeyType.OKP:
                     {
-                        MakeEdDSA(out var privateKeySeed, out byte[] publicKey, out byte[] expandedPrivateKey);
+                        MakeEdDSA(out var privateKeySeed, out byte[] publicKey, out _);
                         cpk = MakeCredentialPublicKey(kty, alg, COSE.EllipticCurve.Ed25519, publicKey);
                         break;
                     }


### PR DESCRIPTION
- Minor formats
- Use CborMap overloads to reduce casting
- Use init properties
- Improve X509Certificate2 construction from x5c arrays
- Construct trustRoot sooner, to reuse X509Certificate2 instance
- Update CredentialPublicKey constructor to use COSE.Algorithm 
- Use built-in DateTimeOffset.UnixEpoch