### PR TITLE
Fix old links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FIDO2 .NET Library (WebAuthn)
 A working implementation library + demo for [FIDO2](https://fidoalliance.org/fido2/) and [WebAuthn](https://www.w3.org/TR/webauthn/) using [.NET](https://dotnet.microsoft.com/)  
 [![Build Status](https://dev.azure.com/anders/Fido2/_apis/build/status/abergs.fido2-net-lib?branchName=master)](https://dev.azure.com/anders/Fido2/_build/latest?definitionId=10&branchName=master)
-[![codecov](https://codecov.io/gh/passwordless-lib/fido2-net-lib/branch/master/graph/badge.svg)](https://codecov.io/gh/abergs/fido2-net-lib)
+[![codecov](https://codecov.io/gh/passwordless-lib/fido2-net-lib/branch/master/graph/badge.svg)](https://codecov.io/gh/passwordless-lib/fido2-net-lib)
 [![Financial Contributors on Open Collective](https://opencollective.com/passwordless/all/badge.svg?label=financial+contributors)](https://opencollective.com/passwordless)
-[![NuGet Status](http://img.shields.io/nuget/v/Fido2.svg?style=flat-square)](https://www.nuget.org/packages/Fido2/) [Releases & Change log](https://github.com/abergs/fido2-net-lib/releases)
+[![NuGet Status](http://img.shields.io/nuget/v/Fido2.svg?style=flat-square)](https://www.nuget.org/packages/Fido2/) [Releases & Change log](https://github.com/passwordless-lib/fido2-net-lib/releases)
 
 ### 💡 Passwordless API now available!
 
@@ -49,7 +49,7 @@ Read more:
 
 - ✅ Attestation API & verification (Register and verify credentials/authenticators)  
 - ✅ Assertion API & verification (Authenticate users)
-- ✅ 100% pass rate in [conformance testing](#conformance-testing-tool) ([results](https://github.com/abergs/fido2-net-lib/issues/13#issuecomment-457318859))
+- ✅ 100% pass rate in [conformance testing](#conformance-testing-tool) ([results](https://github.com/passwordless-lib/fido2-net-lib/issues/13#issuecomment-457318859))
 - ✅ FIDO2 security keys aka roaming authenticators ([spec](https://www.w3.org/TR/webauthn/#roaming-authenticators)), like SoloKeys [Solo](https://github.com/solokeys/solo/blob/master/README.md), Yubico [YubiKey](https://www.yubico.com/products/yubikey-hardware/), and Feitian [BioPass FIDO2](https://www.ftsafe.com/Products/FIDO2))
 - ✅ Device embedded authenticators aka platform authenticators ([spec](https://www.w3.org/TR/webauthn/#platform-authenticators)), like [Android Key](https://source.android.com/security/keystore/attestation) and [TPM](https://trustedcomputinggroup.org/resource/trusted-platform-module-2-0-a-brief-introduction/))
 - ✅ Backwards compatibility with FIDO U2F authenticators ([spec](https://www.w3.org/TR/#conforming-authenticators-u2f))
@@ -61,12 +61,12 @@ Read more:
 - ✅ WebAuthn extensions ([spec](https://www.w3.org/TR/webauthn/#extensions))
 - ✅ Examples & demos
 - ✅ Intellisense documentation
-- 💤 [Formal documentation](https://github.com/abergs/fido2-net-lib/issues/53)
-- 💤 Recommended [usage patterns](https://github.com/abergs/fido2-net-lib/issues/54)
+- 💤 [Formal documentation](https://github.com/passwordless-lib/fido2-net-lib/issues/53)
+- 💤 Recommended [usage patterns](https://github.com/passwordless-lib/fido2-net-lib/issues/54)
 
 ## Configuration
 
-  *Only some options are mentioned here, see the [Configuration](https://github.com/abergs/fido2-net-lib/blob/master/fido2-net-lib/Fido2NetLib.cs) class for all options*
+  *Only some options are mentioned here, see the [Configuration](https://github.com/passwordless-lib/fido2-net-lib/blob/master/fido2-net-lib/Fido2NetLib.cs) class for all options*
 
 * `fido2:MDSCacheDirPath` - App Secret / environment variable that sets the cache path for the MDS. Defaults to "current user's temporary folder"/fido2mdscache. *Optional when using the default [MetadataService provider](https://fidoalliance.org/mds/).*
 
@@ -76,7 +76,7 @@ See the [demo controller](Demo/Controller.cs) for full examples of both [attesta
 
 See the [test controller](Demo/TestController.cs) for examples of how to pass the [conformance tests](#conformance-testing-tool).
 
-See the [Active Directory Store information](https://github.com/abergs/fido2-net-lib/issues/68#issuecomment-451758622) and [example credential store](https://github.com/abergs/fido2-net-lib/blob/ActiveDirectory/fido2-net-lib/ActiveDirectoryStore.cs) for ideas on how to integrate this library with an on-premises Active Directory.
+See the [Active Directory Store information](https://github.com/passwordless-lib/fido2-net-lib/issues/68#issuecomment-451758622) and [example credential store](https://github.com/passwordless-lib/fido2-net-lib/blob/ActiveDirectory/fido2-net-lib/ActiveDirectoryStore.cs) for ideas on how to integrate this library with an on-premises Active Directory.
 
 ### Create attestation Options
 
@@ -215,8 +215,8 @@ For more information see the [.NET Foundation Code of Conduct](https://dotnetfou
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](https://github.com/abergs/fido2-net-lib/tree/master#contributing)].
-<a href="https://github.com/abergs/fido2-net-lib/graphs/contributors"><img src="https://opencollective.com/passwordless/contributors.svg?width=890&button=false" /></a>
+This project exists thanks to all the people who contribute. [[Contribute](https://github.com/passwordless-lib/fido2-net-lib/tree/master#contributing)].
+<a href="https://github.com/passwordless-lib/fido2-net-lib/graphs/contributors"><img src="https://opencollective.com/passwordless/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors
 


### PR DESCRIPTION
Updated readme, replacing github.com/abergs to the new organisations, github.com/passwordless-lib