### PR TITLE
Add .Net 6 as supported framework

### DIFF
--- a/Demo/.config/dotnet-tools.json
+++ b/Demo/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-aspnet-codegenerator": {
+      "version": "6.0.0",
+      "commands": [
+        "dotnet-aspnet-codegenerator"
+      ]
+    }
+  }
+}

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,16 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />
     <ProjectReference Include="..\Src\Fido2.Models\Fido2.Models.csproj" />
     <ProjectReference Include="..\Src\Fido2\Fido2.csproj" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />    
   </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="wwwroot\bulma\" />

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
+    <RootNamespace>Fido2Demo</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />

--- a/Demo/Pages/custom.cshtml
+++ b/Demo/Pages/custom.cshtml
@@ -72,7 +72,7 @@
         </div>
 
         <partial name="_options.cshtml" />
-        @Html.Partial("_options.cshtml")
+        @await Html.PartialAsync("_options.cshtml")
 
         <div class="section">
             <div class="container">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   
   <!-- Global Variables -->
   <PropertyGroup>
-    <SupportedTargetFrameworks>net5.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks>net5.0;net6.0</SupportedTargetFrameworks>
   </PropertyGroup>
   
   <!-- Language + Compiler Settings-->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
   <!-- Global Variables -->
   <PropertyGroup>
     <SupportedTargetFrameworks>net5.0;net6.0</SupportedTargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <!-- Language + Compiler Settings-->

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Fido2NetLib</RootNamespace>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Src/Fido2.Models/Fido2Configuration.cs
+++ b/Src/Fido2.Models/Fido2Configuration.cs
@@ -48,7 +48,12 @@ namespace Fido2NetLib
         /// </summary>
         public HashSet<string> Origins
         {
-            get => _origins ?? new HashSet<string> { Origin };
+            get => _origins ?? new HashSet<string>
+            {
+#pragma warning disable CS0618
+                Origin
+#pragma warning restore CS0618
+            };
             set
             {
                 _origins = value;
@@ -61,7 +66,12 @@ namespace Fido2NetLib
         /// </summary>
         public HashSet<string> FullyQualifiedOrigins
         {
-            get => _fullyQualifiedOrigins ?? new HashSet<string> { Origin?.ToFullyQualifiedOrigin() };
+            get => _fullyQualifiedOrigins ?? new HashSet<string>
+            {
+#pragma warning disable CS0618
+                Origin?.ToFullyQualifiedOrigin()
+#pragma warning restore CS0618
+            };
             private set => _fullyQualifiedOrigins = value;
         }
 

--- a/Src/Fido2/AttestationFormat/AndroidSafetyNet.cs
+++ b/Src/Fido2/AttestationFormat/AndroidSafetyNet.cs
@@ -16,7 +16,7 @@ namespace Fido2NetLib
 {
     internal sealed class AndroidSafetyNet : AttestationVerifier
     {
-        private readonly int _driftTolerance;
+        private const int _driftTolerance = 0;
 
         private static X509Certificate2 GetX509Certificate(string certString)
         {

--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-﻿#nullable disable
+#nullable disable
 
 using System.Linq;
 using System.Security.Cryptography;

--- a/Src/Fido2/Cbor/CborMap.cs
+++ b/Src/Fido2/Cbor/CborMap.cs
@@ -166,8 +166,10 @@ namespace Fido2NetLib.Cbor
             throw new KeyNotFoundException($"Key '{key}' not found");
         }
 
+
         public CborObject? this[CborObject key]
         {
+#pragma warning disable CS8766
             get
             {
                 foreach (var item in items)
@@ -178,8 +180,9 @@ namespace Fido2NetLib.Cbor
                     }
                 }
 
-                return null!;
+                return null;
             }
+#pragma warning restore CS8766
         }
 
         public override CborObject? this[string name]

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
    
   <ItemGroup>

--- a/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
+++ b/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
@@ -28,14 +28,13 @@ namespace Fido2NetLib
                                         "xubSa3y3v5ormpPqCwfqn9s0MLBAtzCIgxQ/zkzPKctkiwoPtDzI51KnAjAmeMyg" +
                                         "X2S5Ht8+e+EQnezLJBJXtnkRWY+Zt491wgt/AwSs5PHHMv5QgjELOuMxQBc=";
 
-        private readonly string? _blobUrl;
         private readonly HttpClient _httpClient;
 
-        private readonly string _origin = "http://localhost";
+        private readonly string _origin;
 
         private readonly string _getEndpointsUrl = "https://mds3.certinfra.fidoalliance.org/getEndpoints";
 
-        public ConformanceMetadataRepository(HttpClient client, string origin)
+        public ConformanceMetadataRepository(HttpClient? client, string origin)
         {
             _httpClient = client ?? new HttpClient();
             _origin = origin;
@@ -82,7 +81,7 @@ namespace Fido2NetLib
                     continue;
                 }
                 
-                if(string.Compare(blob.NextUpdate, combinedBlob.NextUpdate) < 0)
+                if(string.Compare(blob.NextUpdate, combinedBlob.NextUpdate, StringComparison.InvariantCulture) < 0)
                     combinedBlob.NextUpdate = blob.NextUpdate;
                 if (combinedBlob.Number < blob.Number)
                     combinedBlob.Number = blob.Number;
@@ -98,12 +97,12 @@ namespace Fido2NetLib
             return combinedBlob;
         }
 
-        protected Task<string> DownloadStringAsync(string url)
+        private Task<string> DownloadStringAsync(string url)
         {
             return _httpClient.GetStringAsync(url);
         }
 
-        protected Task<byte[]> DownloadDataAsync(string url)
+        private Task<byte[]> DownloadDataAsync(string url)
         {
             return _httpClient.GetByteArrayAsync(url);
         }

--- a/Test/.config/dotnet-tools.json
+++ b/Test/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.0.0",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/Test/Attestation/Apple.cs
+++ b/Test/Attestation/Apple.cs
@@ -273,7 +273,7 @@ namespace Test.Attestation
             {
                 ServerDomain = "6cc3c9e7967a.ngrok.io",
                 ServerName = "6cc3c9e7967a.ngrok.io",
-                Origin = "https://www.passwordless.dev",
+                Origins = new HashSet<string> { "https://www.passwordless.dev" },
             });
 
             var credentialMakeResult = lib.MakeNewCredentialAsync(attestationResponse, origChallenge, callback);

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -314,7 +314,7 @@ namespace Test
 
         [Theory]
         [InlineData(new byte[] { 0x66, 0x6f, 0x6f })]
-        public async void TestAuthenticatorAttestationObjectBadCBOR(byte[] value)
+        public void TestAuthenticatorAttestationObjectBadCBOR(byte[] value)
         {
             var rawResponse = new AuthenticatorAttestationRawResponse
             {

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -284,6 +284,7 @@ namespace fido2_net_lib.Test
                             privateKey = Key.Import(SignatureAlgorithm.Ed25519, expandedPrivateKey, KeyBlobFormat.RawPrivateKey);
                             break;
                         }
+                    default:
                         throw new ArgumentOutOfRangeException(nameof(kty), $"Missing or unknown kty {kty}");
                 }
 
@@ -872,6 +873,7 @@ namespace fido2_net_lib.Test
                             cpk = MakeCredentialPublicKey(kty, alg, COSE.EllipticCurve.Ed25519, publicKey);
                             break;
                         }
+                    default:
                         throw new ArgumentOutOfRangeException(nameof(kty), $"Missing or unknown kty {kty}");
                 }
             }
@@ -1075,6 +1077,7 @@ namespace fido2_net_lib.Test
                         cpk = MakeCredentialPublicKey(kty, alg, COSE.EllipticCurve.Ed25519, publicKey);
                         break;
                     }
+                default:
                     throw new ArgumentException(nameof(kty), $"Missing or unknown kty {kty}");
             }
             return cpk;

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="ReportGenerator" Version="4.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="ReportGenerator" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,10 +13,14 @@
     </Content>
     <None Include="@(TestFiles)" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />
     <ProjectReference Include="..\Src\Fido2.Models\Fido2.Models.csproj" />
     <ProjectReference Include="..\Src\Fido2\Fido2.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,76 +4,100 @@ name: $(Rev:r)
 variables:
   BuildConfiguration: Release
   TargetVmImage: windows-latest
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
 
 jobs:
-# Prepare the environment for the other tasks
-- job: prepare
-  displayName: Prepare environment
-  pool:
-    vmImage: $(TargetVmImage)
-  steps:
-  - task: NuGetToolInstaller@1
-    displayName: Install latest NuGet
-  - task: UseDotNet@2
-    displayName: 'Use .NET 5.0 SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '5.0.x'
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      includeNuGetOrg: true
-      noCache: true
-
-# Build the main library
-- job: lib
-  displayName: Library build
-  pool:
-    vmImage: $(TargetVmImage)
-  dependsOn: prepare
-  steps:
-  - task: PowerShell@2
-    displayName: Run build script (lib only, release mode)
-    inputs:
-      targetType: filePath
-      filePath: ./scripts/buildRelease.ps1
-      arguments: '"-p:Version=$(Build.BuildNumber)-development"'
-
 # Publish the demo website
 - job: demo
   displayName: Demo build
   pool:
     vmImage: $(TargetVmImage)
-  dependsOn: lib
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET 5.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '5.0.x'
+      installationPath: $(Agent.ToolsDirectory)/dotnet-demo
+  - task: UseDotNet@2
+    displayName: 'Use .NET 6.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+      installationPath: $(Agent.ToolsDirectory)/dotnet-demo
   - task: DotNetCoreCLI@2
-    displayName: Publish website
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: 'Demo/Demo.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build $(buildConfiguration)'
+    inputs:
+      command: build
+      arguments: '--configuration $(buildConfiguration) --no-restore --nologo "-p:Version=$(Build.BuildNumber)-development"'
+      projects: 'Demo/Demo.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: Publish website [net5.0]
     inputs:
       command: publish
-      arguments: '--configuration $(BuildConfiguration) --output $(build.ArtifactStagingDirectory) --framework net5.0'
-  - task: PublishBuildArtifacts@1
-    displayName: Copy website to artifacts
+      arguments: '--no-build --nologo --configuration $(BuildConfiguration) --output $(build.ArtifactStagingDirectory)/net5.0 /p:PackageVersion=$(Build.BuildNumber)-development --framework net5.0'
+      projects: 'Demo/Demo.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: Publish website [net6.0]
     inputs:
-      ArtifactName: demodrop
+      command: publish
+      arguments: '--no-build --nologo --configuration $(BuildConfiguration) --output $(build.ArtifactStagingDirectory)/net6.0 /p:PackageVersion=$(Build.BuildNumber)-development --framework net6.0'
+      projects: 'Demo/Demo.csproj'
+  - task: PublishBuildArtifacts@1
+    displayName: Copy website to artifacts [net5.0]
+    inputs:
+      pathToPublish: $(build.ArtifactStagingDirectory)/net5.0
+      artifactName: Demo .Net 5.0
+  - task: PublishBuildArtifacts@1
+    displayName: Copy website to artifacts [net6.0]
+    inputs:
+      pathToPublish: $(build.ArtifactStagingDirectory)/net6.0
+      artifactName: Demo .Net 6.0
 
 # Run unit tests
 - job: tests
   displayName: Unit tests
   pool:
     vmImage: $(TargetVmImage)
-  dependsOn: lib
   steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET 5.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '5.0.x'
+      installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
+  - task: UseDotNet@2
+    displayName: 'Use .NET 6.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+      installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: 'Test/Test.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build $(buildConfiguration)'
+    inputs:
+      command: build
+      arguments: '--configuration $(buildConfiguration) --no-restore --nologo "-p:Version=$(Build.BuildNumber)-development"'
+      projects: 'Test/Test.csproj'
   - task: DotNetCoreCLI@2
     displayName: Run unit tests
     inputs:
       command: test
-      projects: '**/Test.csproj'
-      arguments: --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="**/ExternalLibs/**"
+      projects: 'Test/Test.csproj'
+      arguments: '--configuration $(buildConfiguration) --no-restore --no-build --nologo --collect:"XPlat Code Coverage"'
   - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
     displayName: ReportGenerator
     inputs:
-      reports: '$(Build.SourcesDirectory)/Test/coverage.net5.0.cobertura.xml'
+      reports: '$(Agent.TempDirectory)\**\coverage.cobertura.xml'
       targetdir: '$(Build.SourcesDirectory)/CodeCoverage'
       reporttypes: 'HtmlInline_AzurePipelines;Cobertura;Badges'
       assemblyfilters: '-xunit*'
@@ -87,4 +111,4 @@ jobs:
     displayName: 'Upload coverage to Codecov'
     inputs:
       targetType: 'inline'
-      script: 'bash <(curl -s https://codecov.io/bash) -t 0b864a87-d3bc-4130-b942-81909f1064c0'
+      script: 'bash <(curl -s https://codecov.io/bash) -Z -t 0b864a87-d3bc-4130-b942-81909f1064c0 -f CodeCoverage/Cobertura.xml'


### PR DESCRIPTION
Hi, there is already the .Net6 framework.
I prepared this small PR that adds it right next to the .Net5.

I found (and [resolved](https://github.com/trejjam/fido2-net-lib/commit/079b2e38f17cdab8be488e1f97c241d6681470e2)) one deprecation in packages: https://github.com/aspnet/Announcements/issues/303