### PR TITLE
Improve Code Quality 7

### DIFF
--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -7,7 +7,7 @@ using Fido2NetLib.Objects;
 
 namespace Fido2NetLib
 {
-    internal class Packed : AttestationVerifier
+    internal sealed class Packed : AttestationVerifier
     {
         private static readonly string[] s_newLine = new string[] { Environment.NewLine };
 

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -111,23 +111,21 @@ namespace Fido2NetLib
             // Handled in CertInfo constructor, see CertInfo.Type
 
             // 4c. Verify that extraData is set to the hash of attToBeSigned using the hash algorithm employed in "alg"
-            if (!(Alg is CborInteger))
+            if (Alg is not CborInteger)
                 throw new Fido2VerificationException("Invalid TPM attestation algorithm");
 
             var alg = (COSE.Algorithm)(int)Alg;
 
-            using (HashAlgorithm hasher = CryptoUtils.GetHasher(CryptoUtils.HashAlgFromCOSEAlg(alg)))
-            {
-                if (!hasher.ComputeHash(Data).AsSpan().SequenceEqual(certInfo.ExtraData))
-                    throw new Fido2VerificationException("Hash value mismatch extraData and attToBeSigned");
-            }
-
+            ReadOnlySpan<byte> dataHash = CryptoUtils.HashData(CryptoUtils.HashAlgFromCOSEAlg(alg), Data);
+            
+            if (!dataHash.SequenceEqual(certInfo.ExtraData))
+                throw new Fido2VerificationException("Hash value mismatch extraData and attToBeSigned");
+            
             // 4d. Verify that attested contains a TPMS_CERTIFY_INFO structure, whose name field contains a valid Name for pubArea, as computed using the algorithm in the nameAlg field of pubArea 
-            using (HashAlgorithm hasher = CryptoUtils.GetHasher(CryptoUtils.HashAlgFromCOSEAlg((COSE.Algorithm)certInfo.Alg)))
-            {
-                if (!hasher.ComputeHash(pubArea.Raw).AsSpan().SequenceEqual(certInfo.AttestedName))
-                    throw new Fido2VerificationException("Hash value mismatch attested and pubArea");
-            }
+            ReadOnlySpan<byte> pubAreaRawHash = CryptoUtils.HashData(CryptoUtils.HashAlgFromCOSEAlg((COSE.Algorithm)certInfo.Alg), pubArea.Raw);
+           
+            if (!pubAreaRawHash.SequenceEqual(certInfo.AttestedName))
+                throw new Fido2VerificationException("Hash value mismatch attested and pubArea");            
 
             // 4e. Note that the remaining fields in the "Standard Attestation Structure" [TPMv2-Part1] section 31.2, i.e., qualifiedSigner, clockInfo and firmwareVersion are ignored. These fields MAY be used as an input to risk engines.
 

--- a/Src/Fido2/CryptoUtils.cs
+++ b/Src/Fido2/CryptoUtils.cs
@@ -7,7 +7,7 @@ using Fido2NetLib.Objects;
 
 namespace Fido2NetLib
 {
-    public static class CryptoUtils
+    internal static class CryptoUtils
     {
         public static byte[] HashData(HashAlgorithmName hashName, ReadOnlySpan<byte> data)
         {

--- a/Src/Fido2/CryptoUtils.cs
+++ b/Src/Fido2/CryptoUtils.cs
@@ -55,12 +55,14 @@ namespace Fido2NetLib
             // A trust anchor can be a root certificate, an intermediate CA certificate or even the attestation certificate itself.
 
             // Let's check the simplest case first.  If subject and issuer are the same, and the attestation cert is in the list, that's all the validation we need
-            if (trustPath.Length == 1 && trustPath[0].Subject.CompareTo(trustPath[0].Issuer) == 0)
+            if (trustPath.Length == 1 && trustPath[0].Subject.Equals(trustPath[0].Issuer, StringComparison.Ordinal))
             {
                 foreach (X509Certificate2? cert in attestationRootCertificates)
                 {
-                    if (cert.Thumbprint.CompareTo(trustPath[0].Thumbprint) == 0)
+                    if (cert.Thumbprint.Equals(trustPath[0].Thumbprint, StringComparison.Ordinal))
+                    {
                         return true;
+                    }
                 }
                 return false;
             }

--- a/Src/Fido2/CryptoUtils.cs
+++ b/Src/Fido2/CryptoUtils.cs
@@ -9,33 +9,16 @@ namespace Fido2NetLib
 {
     public static class CryptoUtils
     {
-        public static HashAlgorithm GetHasher(HashAlgorithmName hashName)
+        public static byte[] HashData(HashAlgorithmName hashName, ReadOnlySpan<byte> data)
         {
-            switch (hashName.Name)
+            return hashName.Name switch
             {
-                case "SHA1":
-                    return SHA1.Create();
-                case "SHA256":
-                case "HS256":
-                case "RS256":
-                case "ES256":
-                case "PS256":
-                    return SHA256.Create();
-                case "SHA384":
-                case "HS384":
-                case "RS384":
-                case "ES384":
-                case "PS384":
-                    return SHA384.Create();
-                case "SHA512":
-                case "HS512":
-                case "RS512":
-                case "ES512":
-                case "PS512":
-                    return SHA512.Create();
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(hashName));
-            }
+                "SHA1"                                               => SHA1.HashData(data),
+                "SHA256" or "HS256" or "RS256" or "ES256" or "PS256" => SHA256.HashData(data),
+                "SHA384" or "HS384" or "RS384" or "ES384" or "PS384" => SHA384.HashData(data),
+                "SHA512" or "HS512" or "RS512" or "ES512" or "PS512" => SHA512.HashData(data),
+                _ => throw new ArgumentOutOfRangeException(nameof(hashName)),
+            };
         }
 
         public static HashAlgorithmName HashAlgFromCOSEAlg(COSE.Algorithm alg)

--- a/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
+++ b/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
@@ -98,12 +98,12 @@ namespace Fido2NetLib
             return combinedBlob;
         }
 
-        protected Task<string> DownloadStringAsync(string url)
+        private Task<string> DownloadStringAsync(string url)
         {
             return _httpClient.GetStringAsync(url);
         }
 
-        protected Task<byte[]> DownloadDataAsync(string url)
+        private Task<byte[]> DownloadDataAsync(string url)
         {
             return _httpClient.GetByteArrayAsync(url);
         }

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -173,13 +173,8 @@ namespace Test.Attestation
                                 );
                                 
                                 var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                                byte[] hashedData = _attToBeSignedHash(hashAlg);
-                                
-                                byte[] hashedPubArea;
-                                using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                                {
-                                    hashedPubArea = hasher.ComputeHash(pubArea);
-                                }
+                                byte[] hashedData = _attToBeSignedHash(hashAlg);                              
+                                byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                                
 
                                 byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
@@ -272,15 +267,11 @@ namespace Test.Attestation
 
                                 byte[] data = Concat(_authData, _clientDataHash);
 
-                                byte[] hashedData;
-                                byte[] hashedPubArea;
                                 var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                                using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                                {
-                                    hashedData = hasher.ComputeHash(data);
-                                    hashedPubArea = hasher.ComputeHash(pubArea);
-                                }
-
+                               
+                                byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                                byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                                
                                 byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                                 byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                                 byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -407,14 +398,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
 
-                    using (var hasher = CryptoUtils.GetHasher(CryptoUtils.HashAlgFromCOSEAlg(alg)))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
+
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm1bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -526,14 +514,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -633,14 +617,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
                     var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);                   
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -740,14 +720,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                 
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -855,14 +831,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                 
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -962,14 +934,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
+     
                     var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1069,14 +1038,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1176,14 +1141,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1281,15 +1242,11 @@ namespace Test.Attestation
                         .ToArray();
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea.ToArray());
-                    }
-
+              
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -1388,13 +1345,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    using (var hasher = CryptoUtils.GetHasher(CryptoUtils.HashAlgFromCOSEAlg(alg)))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
@@ -1496,15 +1450,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
 
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1604,14 +1553,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
+
                     var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1729,14 +1674,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1854,14 +1796,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                  
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -1980,14 +1918,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2087,14 +2021,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
+
                     var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2195,14 +2125,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2309,14 +2235,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2417,15 +2339,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -2524,14 +2442,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                   
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2634,14 +2548,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = GetUInt16BigEndianBytes(0);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -2741,14 +2652,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                 
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -2852,15 +2759,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                  
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, new byte[] { 0x00, 0x00 }, hashedPubArea);
@@ -2959,15 +2862,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+           
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
                     var tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length + 1);
@@ -3072,15 +2971,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+                   
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, new byte[] { 0x00, 0x10 }, hashedPubArea);
@@ -3179,14 +3074,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+               
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -3290,15 +3181,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+                
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -3396,14 +3283,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
@@ -3515,14 +3398,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -3626,14 +3505,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                   
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -3740,18 +3615,14 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                  
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
-                    var tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
+                    byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
 
                     byte[] tpm2bName = DataHelper.Concat(
                         tpm2bNameLen,
@@ -3853,14 +3724,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -3960,15 +3827,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -4067,14 +3930,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -4174,15 +4033,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -4282,14 +4137,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                 
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                  
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -4389,15 +4240,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -4498,15 +4345,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -4609,14 +4452,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -4727,15 +4566,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                 
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -4834,14 +4669,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
@@ -4955,14 +4786,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                  
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -5069,14 +4896,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -5184,14 +5007,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -5303,14 +5122,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+                    
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
 
@@ -5421,15 +5236,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
-
+                  
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -5532,14 +5343,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+              
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                  
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -5640,15 +5447,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                   
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -5747,14 +5550,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                    
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
@@ -5871,15 +5670,11 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
 
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                   
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);
+                    
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);
                     byte[] tpm2bName = DataHelper.Concat(tpm2bNameLen, tpmAlg, hashedPubArea);
@@ -5978,14 +5773,10 @@ namespace Test.Attestation
                     );
 
                     byte[] data = Concat(_authData, _clientDataHash);
-                    byte[] hashedData;
-                    byte[] hashedPubArea;
-                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
-                    using (var hasher = CryptoUtils.GetHasher(hashAlg))
-                    {
-                        hashedData = hasher.ComputeHash(data);
-                        hashedPubArea = hasher.ComputeHash(pubArea);
-                    }
+
+                    var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);                    
+                    byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
+                    byte[] hashedPubArea = CryptoUtils.HashData(hashAlg, pubArea);                   
 
                     byte[] extraData = Concat(GetUInt16BigEndianBytes(hashedData.Length), hashedData);
                     byte[] tpm2bNameLen = GetUInt16BigEndianBytes(tpmAlg.Length + hashedPubArea.Length);

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -117,25 +117,14 @@ namespace fido2_net_lib.Test
                     });
                 }
             }
+
             public byte[] _clientDataHash => SHA256.HashData(_clientDataJson);
-            
-            public byte[] _attToBeSigned
-            {
-                get
-                {
-                    byte[] data = new byte[_authData.Length + _clientDataHash.Length];
-                    Buffer.BlockCopy(_authData, 0, data, 0, _authData.Length);
-                    Buffer.BlockCopy(_clientDataHash, 0, data, _authData.Length, _clientDataHash.Length);
-                    return data;
-                }
-            }
+
+            public byte[] _attToBeSigned => DataHelper.Concat(_authData, _clientDataHash);
 
             public byte[] _attToBeSignedHash(HashAlgorithmName alg)
             {
-                using (var hasher = CryptoUtils.GetHasher(alg))
-                {
-                    return hasher.ComputeHash(_attToBeSigned);
-                }
+                return CryptoUtils.HashData(alg, _attToBeSigned);                
             }
 
             public byte[] _credentialID;


### PR DESCRIPTION
- Eliminates HashAlgorithm allocations
- Makes CryptoUtils internal (to allow for future optimizations)
- Replaces CompareTo with Equals 
- Seals Packed AttestationVerifier
- Fix member visibility warning