### PR TITLE
Drop net5.0 support & update depedencies

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
     <RootNamespace>Fido2Demo</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,13 +15,13 @@
   
   <!-- Global Variables -->
   <PropertyGroup>
-    <SupportedTargetFrameworks>net5.0;net6.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks>net6.0</SupportedTargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <!-- Language + Compiler Settings-->
   <PropertyGroup>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   
   <!--MISC-->

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
 

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -16,9 +16,9 @@
   <!-- References -->
   <ItemGroup>
     <ProjectReference Include="..\Fido2.Models\Fido2.Models.csproj" />
-    <PackageReference Include="NSec.Cryptography" Version="20.2.0" />
-    <PackageReference Include="System.Formats.Cbor" Version="5.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
+    <PackageReference Include="NSec.Cryptography" Version="22.4.0" />
+    <PackageReference Include="System.Formats.Cbor" Version="6.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -49,7 +49,7 @@ namespace Test
         [InlineData("https://[0:0:0:0:0:0:0:1]", "https://[0:0:0:0:0:0:0:1]:443")]
         public async Task TestAuthenticatorOrigins(string origin, string expectedOrigin)
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = origin;
             var acd = new AttestedCredentialData(("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-40-FE-6A-32-63-BE-37-D1-01-B1-2E-57-CA-96-6C-00-22-93-E4-19-C8-CD-01-06-23-0B-C6-92-E8-CC-77-12-21-F1-DB-11-5D-41-0F-82-6B-DB-98-AC-64-2E-B1-AE-B5-A8-03-D1-DB-C1-47-EF-37-1C-FD-B1-CE-B0-48-CB-2C-A5-01-02-03-26-20-01-21-58-20-A6-D1-09-38-5A-C7-8E-5B-F0-3D-1C-2E-08-74-BE-6D-BB-A4-0B-4F-2A-5F-2F-11-82-45-65-65-53-4F-67-28-22-58-20-43-E1-08-2A-F3-13-5B-40-60-93-79-AC-47-42-58-AA-B3-97-B8-86-1D-E4-41-B4-4E-83-08-5D-1C-6B-E0-D0").Split('-').Select(c => Convert.ToByte(c, 16)).ToArray());
             var authData = new AuthenticatorData(
@@ -153,7 +153,7 @@ namespace Test
         [InlineData("http://[0:0:0:0:0:0:0:1]", "https://[0:0:0:0:0:0:0:1]:443")]
         public void TestAuthenticatorOriginsFail(string origin, string expectedOrigin)
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = origin;
             var acd = new AttestedCredentialData(("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-40-FE-6A-32-63-BE-37-D1-01-B1-2E-57-CA-96-6C-00-22-93-E4-19-C8-CD-01-06-23-0B-C6-92-E8-CC-77-12-21-F1-DB-11-5D-41-0F-82-6B-DB-98-AC-64-2E-B1-AE-B5-A8-03-D1-DB-C1-47-EF-37-1C-FD-B1-CE-B0-48-CB-2C-A5-01-02-03-26-20-01-21-58-20-A6-D1-09-38-5A-C7-8E-5B-F0-3D-1C-2E-08-74-BE-6D-BB-A4-0B-4F-2A-5F-2F-11-82-45-65-65-53-4F-67-28-22-58-20-43-E1-08-2A-F3-13-5B-40-60-93-79-AC-47-42-58-AA-B3-97-B8-86-1D-E4-41-B4-4E-83-08-5D-1C-6B-E0-D0").Split('-').Select(c => Convert.ToByte(c, 16)).ToArray());
             var authData = new AuthenticatorData(
@@ -230,7 +230,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationRawResponse()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
             {
                 Type = "webauthn.create",
@@ -356,7 +356,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseInvalidType()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new 
             {
@@ -428,7 +428,7 @@ namespace Test
         [InlineData(new byte[0])]
         public void TestAuthenticatorAttestationResponseInvalidRawId(byte[] value)
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new {
                 type = "webauthn.create",
@@ -446,7 +446,7 @@ namespace Test
                     AttestationObject = new CborMap {
                         { "fmt", "testing" },
                         { "attStmt", new CborMap() },
-                        { "authData", new byte[0] }
+                        { "authData", Array.Empty<byte>() }
                     }.Encode(),
                     ClientDataJson = clientDataJson
                 },
@@ -497,7 +497,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseInvalidRawType()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new {
                 type = "webauthn.create",
@@ -515,7 +515,7 @@ namespace Test
                     AttestationObject = new CborMap {
                         { "fmt", "testing" },
                         { "attStmt", new CborMap() },
-                        { "authData", new byte[0] }
+                        { "authData", Array.Empty<byte>() }
                     }.Encode(),
                     ClientDataJson = clientDataJson
                 },
@@ -566,7 +566,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseRpidMismatch()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var authData = new AuthenticatorData(
                 SHA256.HashData(Encoding.UTF8.GetBytes("passwordless.dev")),
@@ -643,7 +643,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseNotUserPresent()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var authData = new AuthenticatorData(
                 SHA256.HashData(Encoding.UTF8.GetBytes(rp)),
@@ -721,7 +721,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseNoAttestedCredentialData()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var authData = new AuthenticatorData(
                 SHA256.HashData(Encoding.UTF8.GetBytes(rp)),
@@ -798,7 +798,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseUnknownAttestationType()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var acd = new AttestedCredentialData(("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-40-FE-6A-32-63-BE-37-D1-01-B1-2E-57-CA-96-6C-00-22-93-E4-19-C8-CD-01-06-23-0B-C6-92-E8-CC-77-12-21-F1-DB-11-5D-41-0F-82-6B-DB-98-AC-64-2E-B1-AE-B5-A8-03-D1-DB-C1-47-EF-37-1C-FD-B1-CE-B0-48-CB-2C-A5-01-02-03-26-20-01-21-58-20-A6-D1-09-38-5A-C7-8E-5B-F0-3D-1C-2E-08-74-BE-6D-BB-A4-0B-4F-2A-5F-2F-11-82-45-65-65-53-4F-67-28-22-58-20-43-E1-08-2A-F3-13-5B-40-60-93-79-AC-47-42-58-AA-B3-97-B8-86-1D-E4-41-B4-4E-83-08-5D-1C-6B-E0-D0").Split('-').Select(c => Convert.ToByte(c, 16)).ToArray());
             var authData = new AuthenticatorData(
@@ -876,7 +876,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseNotUniqueCredId()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var acd = new AttestedCredentialData(("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-40-FE-6A-32-63-BE-37-D1-01-B1-2E-57-CA-96-6C-00-22-93-E4-19-C8-CD-01-06-23-0B-C6-92-E8-CC-77-12-21-F1-DB-11-5D-41-0F-82-6B-DB-98-AC-64-2E-B1-AE-B5-A8-03-D1-DB-C1-47-EF-37-1C-FD-B1-CE-B0-48-CB-2C-A5-01-02-03-26-20-01-21-58-20-A6-D1-09-38-5A-C7-8E-5B-F0-3D-1C-2E-08-74-BE-6D-BB-A4-0B-4F-2A-5F-2F-11-82-45-65-65-53-4F-67-28-22-58-20-43-E1-08-2A-F3-13-5B-40-60-93-79-AC-47-42-58-AA-B3-97-B8-86-1D-E4-41-B4-4E-83-08-5D-1C-6B-E0-D0").Split('-').Select(c => Convert.ToByte(c, 16)).ToArray());
             var authData = new AuthenticatorData(
@@ -953,7 +953,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAttestationResponseUVRequired()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var rp = "https://www.passwordless.dev";
             var acd = new AttestedCredentialData(("00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-40-FE-6A-32-63-BE-37-D1-01-B1-2E-57-CA-96-6C-00-22-93-E4-19-C8-CD-01-06-23-0B-C6-92-E8-CC-77-12-21-F1-DB-11-5D-41-0F-82-6B-DB-98-AC-64-2E-B1-AE-B5-A8-03-D1-DB-C1-47-EF-37-1C-FD-B1-CE-B0-48-CB-2C-A5-01-02-03-26-20-01-21-58-20-A6-D1-09-38-5A-C7-8E-5B-F0-3D-1C-2E-08-74-BE-6D-BB-A4-0B-4F-2A-5F-2F-11-82-45-65-65-53-4F-67-28-22-58-20-43-E1-08-2A-F3-13-5B-40-60-93-79-AC-47-42-58-AA-B3-97-B8-86-1D-E4-41-B4-4E-83-08-5D-1C-6B-E0-D0").Split('-').Select(c => Convert.ToByte(c, 16)).ToArray());
             var authData = new AuthenticatorData(
@@ -1030,7 +1030,7 @@ namespace Test
         [Fact]
         public void TestAuthenticatorAssertionRawResponse()
         {
-            var challenge = RandomGenerator.Default.GenerateBytes(128);
+            var challenge = RandomNumberGenerator.GetBytes(128);
             var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
             {
                 Type = "webauthn.get",

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -21,14 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="ReportGenerator" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5.0 has reached end of life and is no longer supported by Microsoft. 

This PR:

- drops the .NET5.0 target
- updates Microsoft.SourceLink.GitHub to 1.1.1
- updates NSec.Cryptography to latest version (and reacts to the new obsolete methods)
- updates System.IdentityModel.Tokens.Jwt to 16.7
- updates System.Formats.Cbor to 6.0.0
