### PR TITLE
Add TLS endpoint to Demo project launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ ASALocalRun/
 /results
 /Test/coverage.netcoreapp3.1.cobertura.xml
 
+.DS_Store

--- a/Demo/Properties/launchSettings.json
+++ b/Demo/Properties/launchSettings.json
@@ -20,7 +20,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:4729/"
+      "applicationUrl": "http://localhost:4729/;https://localhost:44329/"
     }
   }
 }


### PR DESCRIPTION
Adds both launch URLs to the Demo project config - this issue mostly affects Linux and MacOS users that don't have IIS Express configuration.
This allows the demo to be runnable and usable directly, instead throwing error where the HTTP url and port don't match the configured one