### PR TITLE
 Changed Fido2 configuration Origins to List<string> and updated demo project

### DIFF
--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -48,7 +48,7 @@ namespace Fido2Demo
             {
                 options.ServerDomain = Configuration["fido2:serverDomain"];
                 options.ServerName = "FIDO2 Test";
-                options.Origins = new HashSet<string> { Configuration["fido2:origin"] };
+                options.Origins = new List<string> { Configuration["fido2:origin"] };
                 options.TimestampDriftTolerance = Configuration.GetValue<int>("fido2:timestampDriftTolerance");
                 options.MDSCacheDirPath = Configuration["fido2:MDSCacheDirPath"];
             })

--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -48,7 +48,7 @@ namespace Fido2Demo
             {
                 options.ServerDomain = Configuration["fido2:serverDomain"];
                 options.ServerName = "FIDO2 Test";
-                options.Origins = new List<string> { Configuration["fido2:origin"] };
+                options.Origins = Configuration.GetSection("fido2:origins").Get<List<string>>();
                 options.TimestampDriftTolerance = Configuration.GetValue<int>("fido2:timestampDriftTolerance");
                 options.MDSCacheDirPath = Configuration["fido2:MDSCacheDirPath"];
             })

--- a/Demo/appsettings.json
+++ b/Demo/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "fido2": {
     "serverDomain": "localhost",
-    "origin": "https://localhost:44329",
+    "origins": [ "https://localhost:44329" ],
     "timestampDriftTolerance": 300000
   },  
   "Logging": {

--- a/Src/Fido2.Models/Fido2Configuration.cs
+++ b/Src/Fido2.Models/Fido2Configuration.cs
@@ -46,13 +46,13 @@ namespace Fido2NetLib
         /// <summary>
         /// Server origins, including protocol host and port.
         /// </summary>
-        public HashSet<string> Origins
+        public List<string> Origins
         {
             get
             {
                 if (_origins == null)
                 {
-                    _origins = new HashSet<string>();
+                    _origins = new List<string>();
 
                     // Since we're depricating Origin we ease the transition to move the value automatically, unless its null
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -69,16 +69,16 @@ namespace Fido2NetLib
             set
             {
                 _origins = value;
-                _fullyQualifiedOrigins = new HashSet<string>(value.Select(o => o.ToFullyQualifiedOrigin()), StringComparer.OrdinalIgnoreCase);
+                _fullyQualifiedOrigins = new List<string>(value.Select(o => o.ToFullyQualifiedOrigin()));
             }
         }
 
         /// <summary>
         /// Fully Qualified Server origins, generated automatically from Origins.
         /// </summary>
-        public HashSet<string> FullyQualifiedOrigins
+        public List<string> FullyQualifiedOrigins
         {
-            get => _fullyQualifiedOrigins ?? new HashSet<string>
+            get => _fullyQualifiedOrigins ?? new List<string>
             {
 #pragma warning disable CS0618
                 Origin?.ToFullyQualifiedOrigin()
@@ -111,7 +111,7 @@ namespace Fido2NetLib
         {
         }
 
-        private HashSet<string> _origins;
-        private HashSet<string> _fullyQualifiedOrigins;
+        private List<string> _origins;
+        private List<string> _fullyQualifiedOrigins;
     }
 }

--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -56,7 +56,7 @@ namespace Fido2NetLib
         /// <param name="cancellationToken"></param>
         public async Task<AssertionVerificationResult> VerifyAsync(
             AssertionOptions options,
-            HashSet<string> fullyQualifiedExpectedOrigins,
+            List<string> fullyQualifiedExpectedOrigins,
             byte[] storedPublicKey,
             uint storedSignatureCounter,
             IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredId,

--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -61,7 +61,7 @@ namespace Fido2NetLib
 
         // todo: add TokenBinding https://www.w3.org/TR/webauthn/#dictdef-tokenbinding
 
-        protected void BaseVerify(HashSet<string> fullyQualifiedExpectedOrigins, ReadOnlySpan<byte> originalChallenge, ReadOnlySpan<byte> requestTokenBindingId)
+        protected void BaseVerify(List<string> fullyQualifiedExpectedOrigins, ReadOnlySpan<byte> originalChallenge, ReadOnlySpan<byte> requestTokenBindingId)
         {
             if (Type is not "webauthn.create" && Type is not "webauthn.get")
                 throw new Fido2VerificationException($"Type not equal to 'webauthn.create' or 'webauthn.get'. Was: '{Type}'");

--- a/Test/Attestation/Apple.cs
+++ b/Test/Attestation/Apple.cs
@@ -266,7 +266,7 @@ namespace Test.Attestation
             {
                 ServerDomain = "6cc3c9e7967a.ngrok.io",
                 ServerName = "6cc3c9e7967a.ngrok.io",
-                Origins = new HashSet<string> { "https://www.passwordless.dev" },
+                Origins = new List<string> { "https://www.passwordless.dev" },
             });
 
             var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, origChallenge, callback);

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -116,7 +116,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { expectedOrigin },
+                Origins = new List<string> { expectedOrigin },
             });
 
             var result = await lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback);
@@ -220,7 +220,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { expectedOrigin },
+                Origins = new List<string> { expectedOrigin },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -416,7 +416,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -487,7 +487,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -556,7 +556,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -633,7 +633,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -711,7 +711,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -788,7 +788,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -866,7 +866,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -943,7 +943,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
@@ -1020,7 +1020,7 @@ namespace Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));

--- a/Test/ExistingU2fRegistrationDataTests.cs
+++ b/Test/ExistingU2fRegistrationDataTests.cs
@@ -60,7 +60,7 @@ namespace fido2_net_lib.Test
 
             IFido2 fido2 = new Fido2(new Fido2Configuration
             {
-                Origins = new System.Collections.Generic.HashSet<string> { "https://localhost:44336" } //data was generated with this origin
+                Origins = new System.Collections.Generic.List<string> { "https://localhost:44336" } //data was generated with this origin
             });
 
             var res = await fido2.MakeAssertionAsync(authResponse, options, publicKey.Encode(), 0, null);

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -63,7 +63,7 @@ namespace fido2_net_lib.Test
 
             _metadataService = service;
 
-            _config = new Fido2Configuration { Origins = new HashSet<string> { "https://localhost:44329" } };
+            _config = new Fido2Configuration { Origins = new List<string> { "https://localhost:44329" } };
 
             var noCurve = COSE.EllipticCurve.Reserved;
 
@@ -247,7 +247,7 @@ namespace fido2_net_lib.Test
                 {
                     ServerDomain = rp,
                     ServerName = rp,
-                    Origins = new HashSet<string> { rp },
+                    Origins = new List<string> { rp },
                 });
                 
                 var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, origChallenge, callback);
@@ -583,7 +583,7 @@ namespace fido2_net_lib.Test
             var jsonPost = JsonSerializer.Deserialize<AuthenticatorAttestationRawResponse>(await File.ReadAllTextAsync("./attestationAppleResponse.json"));
             var options = JsonSerializer.Deserialize<CredentialCreateOptions>(await File.ReadAllTextAsync("./attestationAppleOptions.json"));
             var o = AuthenticatorAttestationResponse.Parse(jsonPost);
-            var config = new Fido2Configuration { Origins = new HashSet<string> { "https://6cc3c9e7967a.ngrok.io" } };
+            var config = new Fido2Configuration { Origins = new List<string> { "https://6cc3c9e7967a.ngrok.io" } };
             await o.VerifyAsync(options, config, (x, cancellationToken) => Task.FromResult(true), _metadataService, null, CancellationToken.None);
             byte[] ad = o.AttestationObject.AuthData;
             // TODO : Why read ad ? Is the test finished ?
@@ -993,7 +993,7 @@ namespace fido2_net_lib.Test
             {
                 ServerDomain = rp,
                 ServerName = rp,
-                Origins = new HashSet<string> { rp },
+                Origins = new List<string> { rp },
             });
             var existingCredentials = new List<PublicKeyCredentialDescriptor>();
             var cred = new PublicKeyCredentialDescriptor


### PR DESCRIPTION
Change to type to List<string>

Configuration example:

```
  "fido2": {
    "serverDomain": "localhost",
    "origins": [ "https://localhost:44329" ],
    "timestampDriftTolerance": 300000
  },  
```

Use in code:

```
Origins = Configuration.GetSection("fido2:origins").Get<List<string>>();
```