### PR TITLE
IOptions changed to IOptionsMonitor for better options handling.

### DIFF
--- a/Demo/TestController.cs
+++ b/Demo/TestController.cs
@@ -24,13 +24,13 @@ namespace Fido2Demo
         public TestController(IOptions<Fido2Configuration> fido2Configuration)
         {
             _origin = fido2Configuration.Value.FullyQualifiedOrigins.FirstOrDefault();
-
-            _fido2 = new Fido2(new Fido2Configuration
+            
+            _fido2 = new Fido2(new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration
             {
                 ServerDomain = fido2Configuration.Value.ServerDomain,
                 ServerName = fido2Configuration.Value.ServerName,
                 Origins = fido2Configuration.Value.FullyQualifiedOrigins,
-            }, 
+            }), 
             ConformanceTesting.MetadataServiceInstance(
                 System.IO.Path.Combine(fido2Configuration.Value.MDSCacheDirPath, @"Conformance"), _origin)
             );

--- a/Demo/TestOptionsMonitor.cs
+++ b/Demo/TestOptionsMonitor.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace Fido2Demo
+{
+    public class TestOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>
+    {
+        private Action<TOptions, string> _listener;
+
+        public TestOptionsMonitor(TOptions currentValue)
+        {
+            CurrentValue = currentValue;
+        }
+
+        public TOptions CurrentValue { get; private set; }
+
+        public TOptions Get(string name)
+        {
+            return CurrentValue;
+        }
+
+        public void Set(TOptions value)
+        {
+            CurrentValue = value;
+            _listener.Invoke(value, null);
+        }
+
+        public IDisposable OnChange(Action<TOptions, string> listener)
+        {
+            _listener = listener;
+            return null;
+        }
+    }
+}

--- a/Src/Fido2/Fido2NetLib.cs
+++ b/Src/Fido2/Fido2NetLib.cs
@@ -2,6 +2,7 @@
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Fido2NetLib.Objects;
 
 namespace Fido2NetLib
@@ -11,14 +12,16 @@ namespace Fido2NetLib
     /// </summary>
     public partial class Fido2 : IFido2
     {
+        private readonly IOptionsMonitor<Fido2Configuration> _configMonitor;
         private readonly Fido2Configuration _config;
         private readonly IMetadataService? _metadataService;
 
         public Fido2(
-            Fido2Configuration config,
+            IOptionsMonitor<Fido2Configuration> configMonitor,
             IMetadataService? metadataService = null)
         {
-            _config = config;
+            _configMonitor = configMonitor;
+            _config = _configMonitor.CurrentValue;
             _metadataService = metadataService;
         }
 

--- a/Test/Attestation/Apple.cs
+++ b/Test/Attestation/Apple.cs
@@ -262,12 +262,13 @@ namespace Test.Attestation
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = "6cc3c9e7967a.ngrok.io",
                 ServerName = "6cc3c9e7967a.ngrok.io",
                 Origins = new HashSet<string> { "https://www.passwordless.dev" },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, origChallenge, callback);
         }

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-
+using fido2_net_lib.Test;
 using Fido2NetLib;
 using Fido2NetLib.Cbor;
 using Fido2NetLib.Objects;
@@ -112,12 +112,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { expectedOrigin },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var result = await lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback);
         }
@@ -216,12 +217,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { expectedOrigin },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.StartsWith("Fully qualified origin", ex.Result.Message);
@@ -412,12 +414,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("AttestationResponse is not type webauthn.create", ex.Result.Message);
@@ -483,12 +486,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("AttestationResponse is missing Id", ex.Result.Message);
@@ -552,12 +556,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("AttestationResponse is missing type with value 'public-key'", ex.Result.Message);
@@ -629,12 +634,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("Hash mismatch RPID", ex.Result.Message);
@@ -707,12 +713,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("User Present flag not set in authenticator data", ex.Result.Message);
@@ -784,12 +791,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("Attestation flag not set on attestation data", ex.Result.Message);
@@ -862,12 +870,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("Missing or unknown attestation type", ex.Result.Message);
@@ -939,12 +948,13 @@ namespace Test
                 return Task.FromResult(false);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("CredentialId is not unique to this user", ex.Result.Message);
@@ -1016,12 +1026,13 @@ namespace Test
                 return Task.FromResult(true);
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
 
             var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
             Assert.Equal("User Verified flag not set in authenticator data and user verification was required", ex.Result.Message);

--- a/Test/ExistingU2fRegistrationDataTests.cs
+++ b/Test/ExistingU2fRegistrationDataTests.cs
@@ -58,10 +58,11 @@ namespace fido2_net_lib.Test
                 }
             };
 
-            IFido2 fido2 = new Fido2(new Fido2Configuration
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration
             {
                 Origins = new System.Collections.Generic.HashSet<string> { "https://localhost:44336" } //data was generated with this origin
             });
+            IFido2 fido2 = new Fido2(optionsMonitor);
 
             var res = await fido2.MakeAssertionAsync(authResponse, options, publicKey.Encode(), 0, null);
 

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -243,12 +243,13 @@ namespace fido2_net_lib.Test
                     return Task.FromResult(true);
                 };
 
-                IFido2 lib = new Fido2(new Fido2Configuration()
+                var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
                 {
                     ServerDomain = rp,
                     ServerName = rp,
                     Origins = new HashSet<string> { rp },
                 });
+                IFido2 lib = new Fido2(optionsMonitor);
                 
                 var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, origChallenge, callback);
 
@@ -989,12 +990,13 @@ namespace fido2_net_lib.Test
                 UserHandle = userHandle,
             };
 
-            IFido2 lib = new Fido2(new Fido2Configuration()
+            var optionsMonitor = new TestOptionsMonitor<Fido2Configuration>(new Fido2Configuration()
             {
                 ServerDomain = rp,
                 ServerName = rp,
                 Origins = new HashSet<string> { rp },
             });
+            IFido2 lib = new Fido2(optionsMonitor);
             var existingCredentials = new List<PublicKeyCredentialDescriptor>();
             var cred = new PublicKeyCredentialDescriptor
             {

--- a/Test/TestOptionsMonitor.cs
+++ b/Test/TestOptionsMonitor.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+
+namespace fido2_net_lib.Test
+{
+    public class TestOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>
+    {
+        private Action<TOptions, string> _listener;
+
+        public TestOptionsMonitor(TOptions currentValue)
+        {
+            CurrentValue = currentValue;
+        }
+
+        public TOptions CurrentValue { get; private set; }
+
+        public TOptions Get(string name)
+        {
+            return CurrentValue;
+        }
+
+        public void Set(TOptions value)
+        {
+            CurrentValue = value;
+            _listener.Invoke(value, null);
+        }
+
+        public IDisposable OnChange(Action<TOptions, string> listener)
+        {
+            _listener = listener;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
For better cases like multi-tenancy, options need to change after the app is started. We can change the IOptions to IOptionsMonitor to handle this case.

I have updated Main `Fido2` class, and all Test Classes contain `Fido2`.

More explanation in here; https://docs.microsoft.com/en-us/dotnet/core/extensions/options#:~:text=Supports%20named%20options-,IOptionsMonitor%3CTOptions%3E%3A,-Is%20used%20to