### PR TITLE
added [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] annotations to generic enums

### DIFF
--- a/Src/Fido2.Models/Converters/EnumNameMapper.cs
+++ b/Src/Fido2.Models/Converters/EnumNameMapper.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace Fido2NetLib
 {
-    public static class EnumNameMapper<TEnum>
+    public static class EnumNameMapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>
         where TEnum: struct, Enum
     {
         private static readonly Dictionary<TEnum, string> valueToNames = GetIdToNameMap();

--- a/Src/Fido2.Models/Converters/FidoEnumConverter.cs
+++ b/Src/Fido2.Models/Converters/FidoEnumConverter.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Fido2NetLib
 {
 
-    public sealed class FidoEnumConverter<T> : JsonConverter<T>
+    public sealed class FidoEnumConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T> : JsonConverter<T>
         where T: struct, Enum
     {
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Src/Fido2/Extensions/EnumExtensions.cs
+++ b/Src/Fido2/Extensions/EnumExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Fido2NetLib;
 
@@ -12,7 +13,7 @@ public static class EnumExtensions
     /// <param name="ignoreCase">ignores the case when comparing values.</param>
     /// <returns>TEnum.</returns>
     /// <exception cref="ArgumentException">No XmlEnumAttribute code exists for type " + typeof(TEnum).ToString() + " corresponding to value of " + value</exception>
-    public static TEnum ToEnum<TEnum>(this string value, bool ignoreCase = true) where TEnum : struct, Enum
+    public static TEnum ToEnum<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(this string value, bool ignoreCase = true) where TEnum : struct, Enum
     {
         // Try to parse it normally on the first try
         if (Enum.TryParse<TEnum>(value, ignoreCase, out var result))
@@ -33,7 +34,7 @@ public static class EnumExtensions
     /// <typeparam name="TEnum">The type of enum.</typeparam>
     /// <param name="value">The enum's value.</param>
     /// <returns>string.</returns>
-    public static string ToEnumMemberValue<TEnum>(this TEnum value) where TEnum : struct, Enum
+    public static string ToEnumMemberValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum>(this TEnum value) where TEnum : struct, Enum
     {
         return EnumNameMapper<TEnum>.GetName(value);
     }


### PR DESCRIPTION
At the moment the build fails when using .NET SDK `7.0.100-rc.1`
There is a trimming error:

> /fido2-net-lib/Src/Fido2.Models/Converters/EnumNameMapper.cs(68,35): error IL2090: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetFields(BindingFlags)'. The generic parameter 'TEnum' of 'Fido2NetLib.EnumNameMapper<TEnum>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [/Users/filipw/Documents/dev/fido2-net-lib/Src/Fido2.Models/Fido2.Models.csproj::TargetFramework=net6.0]

This PR adds the necessary annotations.
