### PR TITLE
Check return value from Base64.DecodeFromUtf8InPlace(), throw if error

### DIFF
--- a/Src/Fido2.Models/Base64Url.cs
+++ b/Src/Fido2.Models/Base64Url.cs
@@ -134,7 +134,10 @@ namespace Fido2NetLib
                 buffer[encodedLength - 2] = (byte)'=';
             }
 
-            Base64.DecodeFromUtf8InPlace(buffer.AsSpan(0, encodedLength), out int decodedLength);
+            if (OperationStatus.Done != Base64.DecodeFromUtf8InPlace(buffer.AsSpan(0, encodedLength), out int decodedLength))
+            {
+                throw new FormatException("The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.");
+            }
 
             var result = buffer.AsSpan(0, decodedLength).ToArray();
 

--- a/Test/Base64UrlTest.cs
+++ b/Test/Base64UrlTest.cs
@@ -35,4 +35,15 @@ public class Base64UrlTest
             Add(Array.Empty<byte>());
         }
     }
+
+    [Fact]
+    public static void Format_BadBase64Char()
+    {
+        const string Format_BadBase64Char = "The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.";
+        var ex = Assert.Throws<FormatException>(() => Base64Url.Decode("rCQqQMqKVO/geUyc9aENh85Mt2g1JHAUKUG27WZVE68==="));
+        Assert.Equal(Format_BadBase64Char, ex.Message);
+
+        ex = Assert.Throws<FormatException>(() => Base64Url.DecodeUtf8(Encoding.UTF8.GetBytes("rCQqQMqKVO/geUyc9aENh85Mt2g1JHAUKUG27WZVE68===")));
+        Assert.Equal(Format_BadBase64Char, ex.Message);
+    }
 }


### PR DESCRIPTION
FIDO Conformance Tools section Server-ServerAuthenticatorAttestationResponse-Resp-1, test F-3 Send ServerAuthenticatorAttestationResponse sends illegally formatted base64url data for "id" field and expects failure.  We were ignoring the return value from Base64.DecodeFromUtf8InPlace(), so we were not detecting this condition.  This PR aligns us with what Convert.FromBase64CharArray() would throw given the same input string.