### PR TITLE
Add Mac and Linux to test pipeline

### DIFF
--- a/Test/Attestation/None.cs
+++ b/Test/Attestation/None.cs
@@ -4,6 +4,7 @@ using Fido2NetLib;
 using Fido2NetLib.Cbor;
 using Fido2NetLib.Exceptions;
 using Fido2NetLib.Objects;
+using System.Runtime.InteropServices;
 
 namespace Test.Attestation;
 
@@ -19,6 +20,10 @@ public class None : Fido2Tests.Attestation
     {
         Fido2Tests._validCOSEParameters.ForEach(async ((COSE.KeyType, COSE.Algorithm, COSE.EllipticCurve) param) =>
         {
+            // No support for P256K on OSX
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && param.Item3 == COSE.EllipticCurve.P256K)
+                return;
+
             _attestationObject.Add("attStmt", new CborMap());
             _credentialPublicKey = Fido2Tests.MakeCredentialPublicKey(param);
             Fido2.CredentialMakeResult res = null;

--- a/Test/Attestation/Packed.cs
+++ b/Test/Attestation/Packed.cs
@@ -7,6 +7,7 @@ using Fido2NetLib;
 using Fido2NetLib.Cbor;
 using Fido2NetLib.Exceptions;
 using Fido2NetLib.Objects;
+using System.Runtime.InteropServices;
 
 namespace Test.Attestation;
 
@@ -23,6 +24,10 @@ public class Packed : Fido2Tests.Attestation
         Fido2Tests._validCOSEParameters.ForEach(async ((COSE.KeyType, COSE.Algorithm, COSE.EllipticCurve) param) =>
         {
             var (type, alg, crv) = param;
+
+            // No support for P256K on OSX
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && crv == COSE.EllipticCurve.P256K)
+                return;
 
             var signature = SignData(type, alg, crv);
 
@@ -192,6 +197,10 @@ public class Packed : Fido2Tests.Attestation
             {
                 return;
             }
+
+            // No support for P256K on OSX
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && curve == COSE.EllipticCurve.P256K)
+                return;
 
             X509Certificate2 attestnCert;
             DateTimeOffset notBefore = DateTimeOffset.UtcNow;

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -1,5 +1,6 @@
-﻿using System.Buffers.Binary;
+using System.Buffers.Binary;
 using System.Formats.Asn1;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -808,6 +809,10 @@ public class Fido2Tests
         _validCOSEParameters.ForEach(async ((COSE.KeyType, COSE.Algorithm, COSE.EllipticCurve) param) =>
         {
             var (type, alg, curve) = param;
+
+            // No support for P256K on OSX
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && curve == COSE.EllipticCurve.P256K)
+                return;
 
             if (curve != default)
             {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,15 +3,15 @@ name: $(Rev:r)
 
 variables:
   BuildConfiguration: Release
-  TargetVmImage: windows-latest
+  TargetWindowsVMImage: windows-latest
   DOTNET_CLI_TELEMETRY_OPTOUT: '1'
 
 jobs:
-# Publish the demo website
+# Publish the demo website for windows-latest
 - job: demo
   displayName: Demo build
   pool:
-    vmImage: $(TargetVmImage)
+    vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET 6.0 SDK'
@@ -42,11 +42,11 @@ jobs:
       pathToPublish: $(build.ArtifactStagingDirectory)/net6.0
       artifactName: Demo .Net 6.0
 
-# Run unit tests
-- job: tests
-  displayName: Unit tests
+# Run unit tests for windows-latest and publish coverage
+- job: test-windows
+  displayName: Unit test windows
   pool:
-    vmImage: $(TargetVmImage)
+    vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
     displayName: 'Use .NET 6.0 SDK'
@@ -89,3 +89,39 @@ jobs:
     inputs:
       targetType: 'inline'
       script: 'bash <(curl -s https://codecov.io/bash) -Z -t 0b864a87-d3bc-4130-b942-81909f1064c0 -f CodeCoverage/Cobertura.xml'
+
+# Run unit tests for mac/linux
+- job: test-mac-linux
+  displayName: Unit test mac/linux
+  strategy:
+    matrix:
+      linux:
+        imageName: 'ubuntu-latest'
+      mac:
+        imageName: 'macOS-latest'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET 6.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+      installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: 'Test/Test.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build $(buildConfiguration)'
+    inputs:
+      command: build
+      arguments: '--configuration $(buildConfiguration) --no-restore --nologo "-p:Version=$(Build.BuildNumber)-development"'
+      projects: 'Test/Test.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: Run unit tests
+    inputs:
+      command: test
+      projects: 'Test/Test.csproj'
+      arguments: '--configuration $(buildConfiguration) --no-restore --no-build --nologo


### PR DESCRIPTION
Historically there have been several times where we've discovered code changes or test additions that work just fine on Windows, but are broken on Mac or Linux.  This PR should help proactively fill that gap by:

- Marking existing demo/test/coverage jobs to make it clear they are Windows specific
- Adding job to test Mac and Linux
- Updating tests where there are known/expected runtime issues
