### PR TITLE
Improve Code Quality

### DIFF
--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -27,7 +27,7 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, Fido2ErrorMessages.MalformedX5c_FidoU2fAttestation);
             }
 
-            var attCert = new X509Certificate2((byte[])X5c[0]);
+            var attCert = new X509Certificate2((byte[])x5cArray[0]);
 
             // TODO : Check why this variable isn't used. Remove it or use it.
             var u2ftransports = U2FTransportsFromAttnCert(attCert.Extensions);

--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -59,7 +59,7 @@ internal sealed class Packed : AttestationVerifier
 
             for (int i = 0; i < trustPath.Length; i++)
             {
-                if (X5c[i] is CborByteString { Length: > 0 } x5cObject)
+                if (x5cArray[i] is CborByteString { Length: > 0 } x5cObject)
                 {
                     var x5cCert = new X509Certificate2(x5cObject.Value);
 

--- a/Src/Fido2/Extensions/IBufferWriterExtensions.cs
+++ b/Src/Fido2/Extensions/IBufferWriterExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using System;
+using System.Buffers;
 using System.Buffers.Binary;
-using System.IO;
 
 namespace Fido2NetLib;
 
-internal static class BinaryWriterExtensions
+internal static class IBufferWriterExtensions
 {
-    public static void WriteUInt16BigEndian(this BinaryWriter writer, ushort value)
+    public static void WriteUInt16BigEndian(this IBufferWriter<byte> writer, ushort value)
     {
         Span<byte> buffer = stackalloc byte[2];
 
@@ -15,7 +15,7 @@ internal static class BinaryWriterExtensions
         writer.Write(buffer);
     }
 
-    public static void WriteUInt32BigEndian(this BinaryWriter writer, uint value)
+    public static void WriteUInt32BigEndian(this IBufferWriter<byte> writer, uint value)
     {
         Span<byte> buffer = stackalloc byte[4];
 

--- a/Src/Fido2/Extensions/JsonElementExtensions.cs
+++ b/Src/Fido2/Extensions/JsonElementExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 namespace Fido2NetLib;
 
@@ -18,5 +19,30 @@ internal static class JsonElementExtensions
         }
 
         return result;
+    }
+
+    public static bool TryDecodeArrayOfBase64EncodedBytes(this in JsonElement el, [NotNullWhen(true)] out byte[][]? result)
+    {
+        if (el.ValueKind is JsonValueKind.Array)
+        {
+            result = new byte[el.GetArrayLength()][];
+
+            int i = 0;
+
+            try
+            {
+                foreach (var item in el.EnumerateArray())
+                {
+                    result[i++] = item.GetBytesFromBase64()!;
+                }
+
+                return true;
+            }
+            catch { }
+        }
+
+        result = null;
+
+        return false;
     }
 }

--- a/Src/Fido2/Extensions/X509CertificateHelper.cs
+++ b/Src/Fido2/Extensions/X509CertificateHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Fido2NetLib;
+
+internal static class X509CertificateHelper
+{
+    public static X509Certificate2 CreateFromBase64String(string base64String)
+    {
+        byte[] rawData;
+
+        try
+        {
+            rawData = Convert.FromBase64String(base64String);
+        }
+        catch 
+        {
+            throw new Exception("Invalid base64 data found parsing X509 certificate");
+        }
+
+        return CreateFromRawData(rawData);
+    }
+
+    public static X509Certificate2 CreateFromRawData(byte[] rawData)
+    {
+        try
+        {
+            return new X509Certificate2(rawData);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("Could not parse X509 certificate", ex);
+        }
+    }
+}

--- a/Src/Fido2/Objects/AttestedCredentialData.cs
+++ b/Src/Fido2/Objects/AttestedCredentialData.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;

--- a/Src/Fido2/Objects/Extensions.cs
+++ b/Src/Fido2/Objects/Extensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Fido2NetLib.Objects;
+﻿using System;
+
+namespace Fido2NetLib.Objects;
 
 /// <summary>
 /// <see cref="https://www.w3.org/TR/webauthn/#extensions"/>
@@ -6,8 +8,11 @@
 public sealed class Extensions
 {
     private readonly byte[] _extensionBytes;
+
     public Extensions(byte[] extensions)
     {
+        ArgumentNullException.ThrowIfNull(extensions);
+
         _extensionBytes = extensions;
     }
 
@@ -18,4 +23,3 @@ public sealed class Extensions
         return _extensionBytes;
     }
 }
-

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -323,7 +323,7 @@ public class AndroidSafetyNet : Fido2Tests.Attestation
         response = Encoding.UTF8.GetBytes(string.Join(".", jwtParts));
         var attStmt = (CborMap)_attestationObject["attStmt"];
         attStmt.Set("response", new CborByteString(response));
-        var ex = Assert.ThrowsAsync<System.ArgumentException>(() => MakeAttestationResponseAsync());
+        var ex = Assert.ThrowsAnyAsync<Exception>(async () => await MakeAttestationResponseAsync());
         Assert.Equal("Could not parse X509 certificate", ex.Result.Message);
     }
 


### PR DESCRIPTION
This PR:

- Consolidates the X509Certificate constructor / error handlers in X509CertificateHelper. We now throw an improved error message if there was invalid Base64 data.
- Uses the built-in JSON converter to decode base64 data. System.Text.Json can convert directly from the utf-8 bytes using the vectorized Base64 converter.
- Replaces the BinaryWriter with BufferWriter