### PR TITLE
Fixes Fido2Configuration.FullyQualifiedOrigins contains a null entry when configured from a configuration section on .NET 7

### DIFF
--- a/Src/Fido2.Models/Fido2Configuration.cs
+++ b/Src/Fido2.Models/Fido2Configuration.cs
@@ -6,8 +6,8 @@ namespace Fido2NetLib;
 
 public class Fido2Configuration
 {
-    private HashSet<string> _origins;
-    private HashSet<string> _fullyQualifiedOrigins;
+    private ISet<string> _origins;
+    private ISet<string> _fullyQualifiedOrigins;
 
     /// <summary>
     /// Create the configuration for Fido2.
@@ -56,7 +56,7 @@ public class Fido2Configuration
     /// <summary>
     /// Server origins, including protocol host and port.
     /// </summary>
-    public HashSet<string> Origins
+    public ISet<string> Origins
     {
         get
         {
@@ -86,7 +86,7 @@ public class Fido2Configuration
     /// <summary>
     /// Fully Qualified Server origins, generated automatically from Origins.
     /// </summary>
-    public HashSet<string> FullyQualifiedOrigins
+    public ISet<string> FullyQualifiedOrigins
     {
         get => _fullyQualifiedOrigins ?? new HashSet<string>
         {

--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -58,7 +58,7 @@ public sealed class AuthenticatorAssertionResponse : AuthenticatorResponse
     /// <param name="cancellationToken"></param>
     public async Task<AssertionVerificationResult> VerifyAsync(
         AssertionOptions options,
-        HashSet<string> fullyQualifiedExpectedOrigins,
+        ISet<string> fullyQualifiedExpectedOrigins,
         byte[] storedPublicKey,
         uint storedSignatureCounter,
         IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredId,

--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -65,7 +65,7 @@ public class AuthenticatorResponse
 
     // todo: add TokenBinding https://www.w3.org/TR/webauthn/#dictdef-tokenbinding
 
-    protected void BaseVerify(HashSet<string> fullyQualifiedExpectedOrigins, ReadOnlySpan<byte> originalChallenge, ReadOnlySpan<byte> requestTokenBindingId)
+    protected void BaseVerify(ISet<string> fullyQualifiedExpectedOrigins, ReadOnlySpan<byte> originalChallenge, ReadOnlySpan<byte> requestTokenBindingId)
     {
         if (Type is not "webauthn.create" && Type is not "webauthn.get")
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidAuthenticatorResponse, $"Type must be 'webauthn.create' or 'webauthn.get'. Was '{Type}'");


### PR DESCRIPTION
Fixes #359