### PR TITLE
Strongly type AaGuid

### DIFF
--- a/Demo/Controller.cs
+++ b/Demo/Controller.cs
@@ -123,7 +123,7 @@ public class MyController : Controller
                 SignatureCounter = success.Result.Counter,
                 CredType = success.Result.CredType,
                 RegDate = DateTime.Now,
-                AaGuid = success.Result.Aaguid
+                AaGuid = success.Result.AaGuid
             });
 
             // Remove Certificates from success because System.Text.Json cannot serialize them properly. See https://github.com/passwordless-lib/fido2-net-lib/issues/328

--- a/Src/Fido2.AspNet/DistributedCacheMetadataService.cs
+++ b/Src/Fido2.AspNet/DistributedCacheMetadataService.cs
@@ -182,10 +182,8 @@ public class DistributedCacheMetadataService : IMetadataService
 
     public async Task<MetadataBLOBPayloadEntry> GetEntryAsync(Guid aaguid, CancellationToken cancellationToken = default)
     {
-        var aaguidComparisonString = aaguid.ToString("D");
-
         var memCacheEntry = await _memoryCache.GetOrCreateAsync<MetadataBLOBPayloadEntry>(
-            $"{CACHE_PREFIX}:{aaguidComparisonString}",
+            $"{CACHE_PREFIX}:{aaguid}",
             async entry =>
             {
                 foreach (var repo in _repositories)
@@ -193,7 +191,7 @@ public class DistributedCacheMetadataService : IMetadataService
                     var cachedPayload = await GetMemoryCachedPayload(repo, cancellationToken);
                     if (cachedPayload != null)
                     {
-                        var matchingEntry = cachedPayload.Entries?.FirstOrDefault(o => o.AaGuid == aaguidComparisonString);
+                        var matchingEntry = cachedPayload.Entries?.FirstOrDefault(o => o.AaGuid == aaguid);
                         if (matchingEntry != null)
                         {
                             entry.AbsoluteExpiration = GetMemoryCacheAbsoluteExpiryTime(GetNextUpdateTimeFromPayload(cachedPayload));

--- a/Src/Fido2.Models/Metadata/MetadataBLOBPayloadEntry.cs
+++ b/Src/Fido2.Models/Metadata/MetadataBLOBPayloadEntry.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
 
@@ -24,7 +25,7 @@ public sealed class MetadataBLOBPayloadEntry
     /// <para>The Authenticator Attestation GUID.</para>
     /// </summary>
     [JsonPropertyName("aaguid")]
-    public string AaGuid { get; set; }
+    public Guid? AaGuid { get; set; }
 
     /// <summary>
     /// Gets or sets a list of the attestation certificate public key identifiers encoded as hex string.

--- a/Src/Fido2.Models/Metadata/MetadataStatement.cs
+++ b/Src/Fido2.Models/Metadata/MetadataStatement.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Fido2NetLib;
@@ -34,7 +35,7 @@ public class MetadataStatement
     /// <para>Note: FIDO 2 Authenticators support AAGUID, but they don't support AAID.</para>
     /// </remarks>
     [JsonPropertyName("aaguid")]
-    public string AaGuid { get; set; }
+    public Guid? AaGuid { get; set; }
 
     /// <summary>
     /// Gets or sets a list of the attestation certificate public key identifiers encoded as hex string.

--- a/Src/Fido2.Models/Objects/AttestationVerificationSuccess.cs
+++ b/Src/Fido2.Models/Objects/AttestationVerificationSuccess.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 
 namespace Fido2NetLib.Objects;
@@ -12,10 +13,14 @@ public class AttestationVerificationSuccess : AssertionVerificationResult
     public byte[] PublicKey { get; set; }
 
     public Fido2User User { get; set; }
+
     public string CredType { get; set; }
-    public System.Guid Aaguid { get; set; }
+
+    public Guid AaGuid { get; set; }
+
 #nullable enable
     public X509Certificate2? AttestationCertificate { get; set; }
 #nullable disable
+
     public X509Certificate2[] AttestationCertificateChain { get; set; }
 }

--- a/Src/Fido2/AttestationFormat/AttestationVerifier.cs
+++ b/Src/Fido2/AttestationFormat/AttestationVerifier.cs
@@ -71,11 +71,9 @@ public abstract class AttestationVerifier
         return false;
     }
 
-#nullable disable
-
-    internal static byte[] AaguidFromAttnCertExts(X509ExtensionCollection exts)
+    internal static byte[]? AaguidFromAttnCertExts(X509ExtensionCollection exts)
     {
-        byte[] aaguid = null;
+        byte[]? aaguid = null;
         var ext = exts.FirstOrDefault(static e => e.Oid?.Value is "1.3.6.1.4.1.45724.1.1.4"); // id-fido-gen-ce-aaguid
         if (ext != null)
         {
@@ -126,6 +124,8 @@ public abstract class AttestationVerifier
 
         return u2ftransports;
     }
+
+#nullable disable
 
     public virtual (AttestationType, X509Certificate2[]) Verify(CborMap attStmt, byte[] authenticatorData, byte[] clientDataHash)
     {

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -241,7 +241,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
             User = originalOptions.User,
             Counter = authData.SignCount,
             CredType = AttestationObject.Fmt,
-            Aaguid = authData.AttestedCredentialData.AaGuid,
+            AaGuid = authData.AttestedCredentialData.AaGuid,
             AttestationCertificate = trustPath?.FirstOrDefault(),
             AttestationCertificateChain = trustPath ?? Array.Empty<X509Certificate2>(),
         };

--- a/Src/Fido2/ConformanceMetadataService.cs
+++ b/Src/Fido2/ConformanceMetadataService.cs
@@ -48,13 +48,13 @@ public class ConformanceMetadataService : IMetadataService
 
     protected virtual async Task LoadEntryStatementAsync(IMetadataRepository repository, MetadataBLOBPayload blob, MetadataBLOBPayloadEntry entry, CancellationToken cancellationToken)
     {
-        if (entry.AaGuid != null)
+        if (entry.AaGuid.HasValue)
         {
             var statement = await repository.GetMetadataStatementAsync(blob, entry, cancellationToken);
 
-            if (!string.IsNullOrWhiteSpace(statement?.AaGuid))
+            if (statement?.AaGuid is Guid aaGuid)
             {
-                _metadataStatements.TryAdd(Guid.Parse(statement.AaGuid), statement);
+                _metadataStatements.TryAdd(aaGuid, statement);
             }
         }
     }
@@ -65,9 +65,9 @@ public class ConformanceMetadataService : IMetadataService
 
         foreach (var entry in blob.Entries)
         {
-            if (!string.IsNullOrEmpty(entry.AaGuid))
+            if (entry.AaGuid is Guid aaGuid)
             {
-                if (_entries.TryAdd(Guid.Parse(entry.AaGuid), entry))
+                if (_entries.TryAdd(aaGuid, entry))
                 {
                     //Load if it doesn't already exist
                     await LoadEntryStatementAsync(repository, blob, entry, cancellationToken);

--- a/Src/Fido2/Extensions/IBufferWriterExtensions.cs
+++ b/Src/Fido2/Extensions/IBufferWriterExtensions.cs
@@ -8,19 +8,43 @@ internal static class IBufferWriterExtensions
 {
     public static void WriteUInt16BigEndian(this IBufferWriter<byte> writer, ushort value)
     {
-        Span<byte> buffer = stackalloc byte[2];
+        var buffer = writer.GetSpan(2);
 
         BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
 
-        writer.Write(buffer);
+        writer.Advance(2);
     }
 
     public static void WriteUInt32BigEndian(this IBufferWriter<byte> writer, uint value)
     {
-        Span<byte> buffer = stackalloc byte[4];
+        var buffer = writer.GetSpan(4);
 
         BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
 
-        writer.Write(buffer);
+        writer.Advance(4);
+    }
+
+    public static void WriteGuidBigEndian(this IBufferWriter<byte> writer, Guid value)
+    {
+        var buffer = writer.GetSpan(16);
+
+        _ = value.TryWriteBytes(buffer);
+
+        if (BitConverter.IsLittleEndian)
+        {
+            SwapBytes(buffer, 0, 3);
+            SwapBytes(buffer, 1, 2);
+            SwapBytes(buffer, 4, 5);
+            SwapBytes(buffer, 6, 7);
+        }
+
+        writer.Advance(16);
+    }
+
+    private static void SwapBytes(Span<byte> bytes, int index1, int index2)
+    {
+        var temp = bytes[index1];
+        bytes[index1] = bytes[index2];
+        bytes[index2] = temp;
     }
 }

--- a/Src/Fido2/Metadata/FileSystemMetadataRepository.cs
+++ b/Src/Fido2/Metadata/FileSystemMetadataRepository.cs
@@ -27,10 +27,9 @@ public sealed class FileSystemMetadataRepository : IMetadataRepository
         if (_blob is null)
             await GetBLOBAsync(cancellationToken);
 
-        if (!string.IsNullOrEmpty(entry.AaGuid) && Guid.TryParse(entry.AaGuid, out Guid parsedAaGuid))
+        if (entry.AaGuid is Guid aaGuid && _entries.TryGetValue(aaGuid, out var found))
         {
-            if (_entries.ContainsKey(parsedAaGuid))
-                return _entries[parsedAaGuid].MetadataStatement;
+            return found.MetadataStatement;
         }
 
         return null;
@@ -56,7 +55,7 @@ public sealed class FileSystemMetadataRepository : IMetadataRepository
                         } 
                     }
                 };
-                if (null != conformanceEntry.AaGuid) _entries.Add(new Guid(conformanceEntry.AaGuid), conformanceEntry);
+                if (null != conformanceEntry.AaGuid) _entries.Add(conformanceEntry.AaGuid.Value, conformanceEntry);
             }
         }
 

--- a/Test/Attestation/AndroidKey.cs
+++ b/Test/Attestation/AndroidKey.cs
@@ -66,7 +66,7 @@ public class AndroidKey : Fido2Tests.Attestation
         var res = await MakeAttestationResponseAsync();
         Assert.Equal(string.Empty, res.ErrorMessage);
         Assert.Equal("ok", res.Status);
-        Assert.Equal(_aaguid, res.Result.Aaguid);
+        Assert.Equal(_aaguid, res.Result.AaGuid);
         Assert.Equal(_signCount, res.Result.Counter);
         Assert.Equal("android-key", res.Result.CredType);
         Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -103,7 +103,7 @@ public class AndroidSafetyNet : Fido2Tests.Attestation
         var res = await MakeAttestationResponseAsync();
         Assert.Equal(string.Empty, res.ErrorMessage);
         Assert.Equal("ok", res.Status);
-        Assert.Equal(_aaguid, res.Result.Aaguid);
+        Assert.Equal(_aaguid, res.Result.AaGuid);
         Assert.Equal(_signCount, res.Result.Counter);
         Assert.Equal("android-safetynet", res.Result.CredType);
         Assert.Equal(_credentialID, res.Result.CredentialId);
@@ -192,7 +192,7 @@ public class AndroidSafetyNet : Fido2Tests.Attestation
             var res = await MakeAttestationResponseAsync();
             Assert.Equal(string.Empty, res.ErrorMessage);
             Assert.Equal("ok", res.Status);
-            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_aaguid, res.Result.AaGuid);
             Assert.Equal(_signCount, res.Result.Counter);
             Assert.Equal("android-safetynet", res.Result.CredType);
             Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Attestation/FidoU2f.cs
+++ b/Test/Attestation/FidoU2f.cs
@@ -58,7 +58,7 @@ public class FidoU2f : Fido2Tests.Attestation
         var res = await MakeAttestationResponseAsync();
         Assert.Equal(string.Empty, res.ErrorMessage);
         Assert.Equal("ok", res.Status);
-        Assert.Equal(_aaguid, res.Result.Aaguid);
+        Assert.Equal(_aaguid, res.Result.AaGuid);
         Assert.Equal(_signCount, res.Result.Counter);
         Assert.Equal("fido-u2f", res.Result.CredType);
         Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Attestation/None.cs
+++ b/Test/Attestation/None.cs
@@ -32,7 +32,7 @@ public class None : Fido2Tests.Attestation
 
             Assert.Equal(string.Empty, res.ErrorMessage);
             Assert.Equal("ok", res.Status);
-            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_aaguid, res.Result.AaGuid);
             Assert.Equal(_signCount, res.Result.Counter);
             Assert.Equal("none", res.Result.CredType);
             Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Attestation/Packed.cs
+++ b/Test/Attestation/Packed.cs
@@ -40,7 +40,7 @@ public class Packed : Fido2Tests.Attestation
 
             Assert.Equal(string.Empty, res.ErrorMessage);
             Assert.Equal("ok", res.Status);
-            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_aaguid, res.Result.AaGuid);
             Assert.Equal(_signCount, res.Result.Counter);
             Assert.Equal("packed", res.Result.CredType);
             Assert.Equal(_credentialID, res.Result.CredentialId);
@@ -329,7 +329,7 @@ public class Packed : Fido2Tests.Attestation
             }
             Assert.Equal(string.Empty, res.ErrorMessage);
             Assert.Equal("ok", res.Status);
-            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_aaguid, res.Result.AaGuid);
             Assert.Equal(_signCount, res.Result.Counter);
             Assert.Equal("packed", res.Result.CredType);
             Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -303,7 +303,7 @@ public class Tpm : Fido2Tests.Attestation
 
             Assert.Equal(string.Empty, res.ErrorMessage);
             Assert.Equal("ok", res.Status);
-            Assert.Equal(_aaguid, res.Result.Aaguid);
+            Assert.Equal(_aaguid, res.Result.AaGuid);
             Assert.Equal(_signCount, res.Result.Counter);
             Assert.Equal("tpm", res.Result.CredType);
             Assert.Equal(_credentialID, res.Result.CredentialId);
@@ -425,7 +425,7 @@ public class Tpm : Fido2Tests.Attestation
 
         Assert.Equal(string.Empty, res.ErrorMessage);
         Assert.Equal("ok", res.Status);
-        Assert.Equal(_aaguid, res.Result.Aaguid);
+        Assert.Equal(_aaguid, res.Result.AaGuid);
         Assert.Equal(_signCount, res.Result.Counter);
         Assert.Equal("tpm", res.Result.CredType);
         Assert.Equal(_credentialID, res.Result.CredentialId);
@@ -5258,7 +5258,7 @@ public class Tpm : Fido2Tests.Attestation
 
         Assert.Equal(string.Empty, res.ErrorMessage);
         Assert.Equal("ok", res.Status);
-        Assert.Equal(_aaguid, res.Result.Aaguid);
+        Assert.Equal(_aaguid, res.Result.AaGuid);
         Assert.Equal(_signCount, res.Result.Counter);
         Assert.Equal("tpm", res.Result.CredType);
         Assert.Equal(_credentialID, res.Result.CredentialId);

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -503,13 +503,13 @@ public class Fido2Tests
     {
         var input = new MetadataBLOBPayloadEntry()
         {
-            AaGuid = Guid.NewGuid().ToString(),
+            AaGuid = Guid.NewGuid(),
             MetadataStatement = new MetadataStatement(),
             StatusReports = Array.Empty<StatusReport>(),
             TimeOfLastStatusChange = DateTime.UtcNow.ToString("o")
         };
 
-        input.MetadataStatement.AaGuid = Guid.NewGuid().ToString();
+        input.MetadataStatement.AaGuid = Guid.NewGuid();
         input.MetadataStatement.Description = "Test entry";
         input.MetadataStatement.AuthenticatorVersion = 1;
         input.MetadataStatement.Upv = new UafVersion[] { new UafVersion

--- a/Test/MetadataServiceTests.cs
+++ b/Test/MetadataServiceTests.cs
@@ -62,10 +62,10 @@ public class MetadataServiceTests
                 Number = _number,
                 Entries = new MetadataBLOBPayloadEntry[]
             {
-                new MetadataBLOBPayloadEntry()
+                new MetadataBLOBPayloadEntry
                 {
-                    AaGuid = "6d44ba9b-f6ec-2e49-b930-0c8fe920cb73",
-                    MetadataStatement = new MetadataStatement()
+                    AaGuid = Guid.Parse("6d44ba9b-f6ec-2e49-b930-0c8fe920cb73"),
+                    MetadataStatement = new MetadataStatement
                     {
                         Description = "Security Key by Yubico with NFC"
                     }
@@ -137,13 +137,13 @@ public class MetadataServiceTests
             currentTimeClock
         );
 
-        var entryIdString = "6d44ba9b-f6ec-2e49-b930-0c8fe920cb73";
+        var entryIdGuid = Guid.Parse("6d44ba9b-f6ec-2e49-b930-0c8fe920cb73");
 
-        var entry = await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+        var entry = await serviceInstance1.GetEntryAsync(entryIdGuid);
 
         for (int x = 0; x < 10; x++)
         {
-            await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+            await serviceInstance1.GetEntryAsync(entryIdGuid);
         }
 
         Assert.Equal(1, staticClient.GetBLOBAsyncCount);
@@ -152,22 +152,22 @@ public class MetadataServiceTests
 
         var blobEntry = await distributedCache.GetStringAsync("DistributedCacheMetadataService:V2:" + staticClient.GetType().Name + ":TOC");
 
-        var itemEntry = memCache.Get<MetadataBLOBPayloadEntry>("DistributedCacheMetadataService:V2:" + entryIdString);
+        var itemEntry = memCache.Get<MetadataBLOBPayloadEntry>($"DistributedCacheMetadataService:V2:{entryIdGuid}");
 
         Assert.NotNull(blobEntry);
 
-        Assert.Equal(itemEntry.AaGuid, entryIdString);
+        Assert.Equal(itemEntry.AaGuid, entryIdGuid);
 
         currentTimeClock.UtcNow = DateTimeOffset.Parse("2021-11-30 23:59:59.999Z"); //Before next update
 
-        await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+        await serviceInstance1.GetEntryAsync(entryIdGuid);
 
         Assert.Equal(1, staticClient.GetBLOBAsyncCount);
 
         currentTimeClock.UtcNow = DateTimeOffset.Parse("2021-12-02 00:59:59.999Z"); //Before buffer period (25 hours)
 
-        await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
-        await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+        await serviceInstance1.GetEntryAsync(entryIdGuid);
+        await serviceInstance1.GetEntryAsync(entryIdGuid);
 
         Assert.Equal(1, staticClient.GetBLOBAsyncCount);
 
@@ -175,13 +175,13 @@ public class MetadataServiceTests
 
         staticClient.NextUpdate = "2021-12-30";
 
-        await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+        await serviceInstance1.GetEntryAsync(entryIdGuid);
 
         Assert.Equal(2, staticClient.GetBLOBAsyncCount);
 
         currentTimeClock.UtcNow = DateTimeOffset.Parse("2021-12-29 01:00:00.001Z");
 
-        await serviceInstance1.GetEntryAsync(Guid.Parse(entryIdString));
+        await serviceInstance1.GetEntryAsync(entryIdGuid);
 
         Assert.Equal(2, staticClient.GetBLOBAsyncCount);
     }


### PR DESCRIPTION
This PR updates AaGuid fields from a string to a Guid. This eliminates some allocations and the need to parse the Guid later.

Making as a draft until mds3.certinfra.fidoalliance.org goes back online and tests are green. 