### PR TITLE
Enable ImplictUsings on Demo & AspNET & Update Test.Sdk

### DIFF
--- a/Demo/ConformanceTesting.cs
+++ b/Demo/ConformanceTesting.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-using Fido2NetLib;
+﻿using Fido2NetLib;
 
 namespace Fido2Demo;
 

--- a/Demo/Controller.cs
+++ b/Demo/Controller.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 using Fido2NetLib;
 using Fido2NetLib.Development;
 using Fido2NetLib.Objects;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using static Fido2NetLib.Fido2;
@@ -19,7 +13,7 @@ namespace Fido2Demo;
 [Route("api/[controller]")]
 public class MyController : Controller
 {
-    private IFido2 _fido2;
+    private readonly IFido2 _fido2;
     public static IMetadataService _mds;
     public static readonly DevelopmentInMemoryStore DemoStorage = new DevelopmentInMemoryStore();
 

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
     <RootNamespace>Fido2Demo</RootNamespace>
   </PropertyGroup>

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
-
-namespace Fido2Demo;
+﻿namespace Fido2Demo;
 
 public class Program
 {

--- a/Demo/RouteHelperExtensions.cs
+++ b/Demo/RouteHelperExtensions.cs
@@ -1,8 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
+﻿using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Rewrite;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 
 namespace Fido2Demo;

--- a/Demo/Startup.cs
+++ b/Demo/Startup.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Rewrite;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Fido2Demo;
 

--- a/Demo/TestController.cs
+++ b/Demo/TestController.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 using Fido2NetLib;
 using Fido2NetLib.Development;
 using Fido2NetLib.Objects;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
@@ -127,8 +122,8 @@ public class TestController : Controller
         var existingCredentials = DemoStorage.GetCredentialsByUser(user).Select(c => c.Descriptor).ToList();
 
         var uv = assertionClientParams.UserVerification;
-        if (null != assertionClientParams.authenticatorSelection)
-            uv = assertionClientParams.authenticatorSelection.UserVerification;
+        if (null != assertionClientParams.AuthenticatorSelection)
+            uv = assertionClientParams.AuthenticatorSelection.UserVerification;
 
         var exts = new AuthenticationExtensionsClientInputs
         { 
@@ -196,7 +191,7 @@ public class TestController : Controller
     {
         public string Username { get; set; }
         public UserVerificationRequirement? UserVerification { get; set; }
-        public AuthenticatorSelection authenticatorSelection { get; set; }
+        public AuthenticatorSelection AuthenticatorSelection { get; set; }
         public AuthenticationExtensionsClientOutputs Extensions { get; set; }
     }
 

--- a/Src/Fido2.AspNet/DateTimeUtilities.cs
+++ b/Src/Fido2.AspNet/DateTimeUtilities.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Fido2NetLib;
+﻿namespace Fido2NetLib;
 
 internal static class DateTimeUtilities
 {

--- a/Src/Fido2.AspNet/DistributedCacheMetadataService.cs
+++ b/Src/Fido2.AspNet/DistributedCacheMetadataService.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
 

--- a/Src/Fido2.AspNet/Fido2NetLibBuilderExtensions.cs
+++ b/Src/Fido2.AspNet/Fido2NetLibBuilderExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using Fido2NetLib;
+﻿using Fido2NetLib;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/Src/Fido2.AspNet/NullMetadataService.cs
+++ b/Src/Fido2.AspNet/NullMetadataService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Fido2NetLib;
+﻿namespace Fido2NetLib;
 
 internal sealed class NullMetadataService : IMetadataService
 {

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -24,12 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="ReportGenerator" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
+++ b/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
THIS PR:

- reduces some boilerplate code in the Demo & ASPNET projects by enabling ImplictUsings.
- Updates the .NET test SDK, Cloverlet collector, and Moq libraries to their latest versions

A single test is continuing to fail because mds3.certinfra.fidoalliance.org is offline.  

@abergs Ready for review.