### PR TITLE
RFC : Make models immutable

### DIFF
--- a/Src/Fido2.Ctap2/Cbor/CborHelper.cs
+++ b/Src/Fido2.Ctap2/Cbor/CborHelper.cs
@@ -7,48 +7,52 @@ internal sealed class CborHelper
 {
     public static PublicKeyCredentialDescriptor DecodePublicKeyCredentialDescriptor(CborMap map)
     {
-        var result = new PublicKeyCredentialDescriptor();
+        byte[] id = null!;
+        PublicKeyCredentialType type = default;
 
         foreach (var (key, value) in map)
         {
             switch ((string)key)
             {
                 case "id":
-                    result.Id = (byte[])value;
+                    id = (byte[])value;
                     break;
                 case "type" when (value is CborTextString { Value: "public-key" }):
-                    result.Type = PublicKeyCredentialType.PublicKey;
+                    type = PublicKeyCredentialType.PublicKey;
                     break;
             }
         }
 
-        return result;
+        return new PublicKeyCredentialDescriptor(type, id);
     }
 
     public static PublicKeyCredentialUserEntity DecodePublicKeyCredentialUserEntity(CborMap map)
     {
-        var result = new PublicKeyCredentialUserEntity();
+        byte[] id = null!;
+        string name = null!;
+        string displayName = null!;
+        string? icon = null;
 
         foreach (var (key, value) in map)
         {
             switch ((string)key)
             {
                 case "id":
-                    result.Id = (byte[])value;
+                    id = (byte[])value;
                     break;
                 case "name":
-                    result.Name = (string)value;
+                    name = (string)value;
                     break;
                 case "displayName":
-                    result.DisplayName = (string)value;
+                    displayName = (string)value;
                     break;
                 case "icon":
-                    result.Icon = (string)value;
+                    icon = (string)value;
                     break;
             }
         }
 
-        return result;
+        return new PublicKeyCredentialUserEntity(id, name, displayName, icon);
     }
 
     public static string[] ToStringArray(CborObject cborObject)

--- a/Src/Fido2.Models/CredentialCreateOptions.cs
+++ b/Src/Fido2.Models/CredentialCreateOptions.cs
@@ -11,7 +11,6 @@ namespace Fido2NetLib;
 public sealed class CredentialCreateOptions : Fido2ResponseBase
 {
     /// <summary>
-    /// 
     /// This member contains data about the Relying Party responsible for the request.
     /// Its value’s name member is required.
     /// Its value’s id member specifies the relying party identifier with which the credential should be associated.If omitted, its value will be the CredentialsContainer object’s relevant settings object's origin's effective domain.
@@ -146,36 +145,6 @@ public sealed class PubKeyCredParam
     public static readonly PubKeyCredParam PS384   = new(COSE.Algorithm.PS384);
     public static readonly PubKeyCredParam PS512   = new(COSE.Algorithm.PS512);
     public static readonly PubKeyCredParam Ed25519 = new(COSE.Algorithm.EdDSA);
-}
-
-#nullable enable
-/// <summary>
-/// PublicKeyCredentialRpEntity 
-/// </summary>
-public sealed class PublicKeyCredentialRpEntity
-{
-    public PublicKeyCredentialRpEntity(string id, string name, string? icon = null)
-    {
-        Name = name;
-        Id = id;
-        Icon = icon;
-    }
-
-    /// <summary>
-    /// A unique identifier for the Relying Party entity, which sets the RP ID.
-    /// </summary>
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
-
-    /// <summary>
-    /// A human-readable name for the entity. Its function depends on what the PublicKeyCredentialEntity represents:
-    /// </summary>
-    [JsonPropertyName("name")]
-    public string Name { get; set; }
-
-    [JsonPropertyName("icon")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Icon { get; set; }
 }
 #nullable disable
 

--- a/Src/Fido2.Models/Objects/PublicKeyCredentialDescriptor.cs
+++ b/Src/Fido2.Models/Objects/PublicKeyCredentialDescriptor.cs
@@ -12,6 +12,12 @@ namespace Fido2NetLib.Objects;
 /// </summary>
 public sealed class PublicKeyCredentialDescriptor
 {
+    public PublicKeyCredentialDescriptor(byte[] id)
+    {
+        Type = PublicKeyCredentialType.PublicKey;
+        Id = id;
+    }
+
     [JsonConstructor]
     public PublicKeyCredentialDescriptor(PublicKeyCredentialType type, byte[] id, AuthenticatorTransport[]? transports = null)
     {

--- a/Src/Fido2.Models/Objects/PublicKeyCredentialDescriptor.cs
+++ b/Src/Fido2.Models/Objects/PublicKeyCredentialDescriptor.cs
@@ -1,43 +1,44 @@
-﻿using System.Text.Json.Serialization;
+﻿#nullable enable
+
+using System;
+using System.Text.Json.Serialization;
 
 namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// This object contains the attributes that are specified by a caller when referring to a public key credential as an input parameter to the create() or get() methods. It mirrors the fields of the PublicKeyCredential object returned by the latter methods.
-/// Lazy implementation of https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor
-/// todo: Should add validation of values as specified in spec
+/// This object contains the attributes that are specified by a caller when referring to a public key credential as an input parameter to the create() or get() methods.
+/// It mirrors the fields of the PublicKeyCredential object returned by the latter methods.
+/// https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialdescriptor
 /// </summary>
-public class PublicKeyCredentialDescriptor
+public sealed class PublicKeyCredentialDescriptor
 {
-    public PublicKeyCredentialDescriptor(byte[] credentialId)
+    [JsonConstructor]
+    public PublicKeyCredentialDescriptor(PublicKeyCredentialType type, byte[] id, AuthenticatorTransport[]? transports = null)
     {
-        Id = credentialId;
-    }
+        ArgumentNullException.ThrowIfNull(id);
 
-    public PublicKeyCredentialDescriptor()
-    {
-
+        Type = type;
+        Id = id;
+        Transports = transports;
     }
 
     /// <summary>
     /// This member contains the type of the public key credential the caller is referring to.
     /// </summary>
     [JsonPropertyName("type")]
-    public PublicKeyCredentialType? Type { get; set; } = PublicKeyCredentialType.PublicKey;
+    public PublicKeyCredentialType Type { get; }
 
     /// <summary>
     /// This member contains the credential ID of the public key credential the caller is referring to.
     /// </summary>
     [JsonConverter(typeof(Base64UrlConverter))]
     [JsonPropertyName("id")]
-    public byte[] Id { get; set; }
-
-#nullable enable
+    public byte[] Id { get; }
 
     /// <summary>
     /// This OPTIONAL member contains a hint as to how the client might communicate with the managing authenticator of the public key credential the caller is referring to.
     /// </summary>
     [JsonPropertyName("transports")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public AuthenticatorTransport[]? Transports { get; set; }
+    public AuthenticatorTransport[]? Transports { get; }
 };

--- a/Src/Fido2.Models/Objects/PublicKeyCredentialUserEntity.cs
+++ b/Src/Fido2.Models/Objects/PublicKeyCredentialUserEntity.cs
@@ -1,17 +1,49 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿#nullable enable
+
+using System;
 
 namespace Fido2NetLib.Objects;
 
 public sealed class PublicKeyCredentialUserEntity
 {
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-    [MaxLength(64)]
-    public byte[] Id { get; set; }
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+    public PublicKeyCredentialUserEntity(byte[] id, string name, string displayName, string? icon = null)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        
+        if (id.Length is 0)
+        {
+            throw new ArgumentException($"Must not be empty", nameof(id));
+        }
 
-    public string Name { get; set; }
+        if (id.Length > 64)
+        {
+            throw new ArgumentException($"Must be 64 bytes or fewer. Was {id.Length} bytes", nameof(id));
+        }
 
-    public string DisplayName { get; set; }
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(displayName);
 
-    public string Icon { get; set; }
+        Id = id;
+        Name = name;
+        DisplayName = displayName;
+        Icon = icon;
+    }
+
+    /// <summary>
+    /// The user handle of the user account entity. 
+    /// A user handle is an opaque byte sequence with a maximum size of 64 bytes, and is not meant to be displayed to the user.
+    /// The user handle MUST NOT contain personally identifying information about the user, such as a username or e-mail address.
+    /// </summary>
+    public byte[] Id { get; }
+
+    public string Name { get; }
+
+    /// <summary>
+    /// A human-palatable name for the user account, intended only for display. For example, "Alex Müller" or "田中倫".
+    /// </summary>
+    public string DisplayName { get; }
+
+    public string? Icon { get; }
 }
+
+// https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialentity

--- a/Src/Fido2.Models/PublicKeyCredentialRpEntity.cs
+++ b/Src/Fido2.Models/PublicKeyCredentialRpEntity.cs
@@ -1,0 +1,40 @@
+﻿#nullable enable
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Fido2NetLib;
+
+/// <summary>
+/// PublicKeyCredentialRpEntity
+/// Provides the details of the relying party with which a credential is associated.
+/// </summary>
+public sealed class PublicKeyCredentialRpEntity
+{
+    [JsonConstructor]
+    public PublicKeyCredentialRpEntity(string id, string name, string? icon = null)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(name);
+
+        Name = name;
+        Id = id;
+        Icon = icon;
+    }
+
+    /// <summary>
+    /// A unique identifier for the Relying Party entity, which sets the RP ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; }
+
+    /// <summary>
+    /// A human-readable name for the entity. Its function depends on what the PublicKeyCredentialEntity represents:
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; }
+
+    [JsonPropertyName("icon")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Icon { get; }
+}

--- a/Src/Fido2.Models/Serialization/FidoModelSerializerContext.cs
+++ b/Src/Fido2.Models/Serialization/FidoModelSerializerContext.cs
@@ -7,6 +7,7 @@ namespace Fido2NetLib.Serialization;
 [JsonSerializable(typeof(MetadataBLOBPayload))]
 [JsonSerializable(typeof(CredentialCreateOptions))]
 [JsonSerializable(typeof(MetadataStatement))]
+[JsonSerializable(typeof(AuthenticatorAttestationRawResponse))]
 public partial class FidoModelSerializerContext : JsonSerializerContext
 {
 }

--- a/Test/ExistingU2fRegistrationDataTests.cs
+++ b/Test/ExistingU2fRegistrationDataTests.cs
@@ -25,11 +25,7 @@ public class ExistingU2fRegistrationDataTests
             RpId = "localhost",
             AllowCredentials = new[]
             {
-                new PublicKeyCredentialDescriptor
-                {
-                      Id = keyHandleData,
-                      Type = PublicKeyCredentialType.PublicKey
-                }
+                new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, keyHandleData)
             },
             Extensions = new AuthenticationExtensionsClientInputs
             {

--- a/Test/ExistingU2fRegistrationDataTests.cs
+++ b/Test/ExistingU2fRegistrationDataTests.cs
@@ -23,9 +23,9 @@ public class ExistingU2fRegistrationDataTests
         {
             Challenge = Base64Url.Decode("mNxQVDWI8+ahBXeQJ8iS4jk5pDUd5KetZGVOwSkw2X0"),
             RpId = "localhost",
-            AllowCredentials = new[]
+            AllowCredentials = new PublicKeyCredentialDescriptor[]
             {
-                new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, keyHandleData)
+                new(keyHandleData)
             },
             Extensions = new AuthenticationExtensionsClientInputs
             {

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -424,7 +424,7 @@ public class Fido2Tests
 
         var credId = "F1-3C-7F-08-3C-A2-29-E0-B4-03-E8-87-34-6E-FC-7F-98-53-10-3A-30-91-75-67-39-7A-D1-D8-AF-87-04-61-87-EF-95-31-85-60-F3-5A-1A-2A-CF-7D-B0-1D-06-B9-69-F9-AB-F4-EC-F3-07-3E-CF-0F-71-E8-84-E8-41-20";
         var allowedCreds = new List<PublicKeyCredentialDescriptor>() {
-            new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, Convert.FromHexString(credId.Replace("-", "")))
+            new(Convert.FromHexString(credId.Replace("-", "")))
         };
 
         // assertion
@@ -1029,7 +1029,7 @@ public class Fido2Tests
             Origins = new HashSet<string> { rp },
         });
         var existingCredentials = new List<PublicKeyCredentialDescriptor>();
-        var cred = new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, new byte[] { 0xf1, 0xd0 });
+        var cred = new PublicKeyCredentialDescriptor(new byte[] { 0xf1, 0xd0 });
         existingCredentials.Add(cred);
 
         var options = lib.GetAssertionOptions(existingCredentials, null, null);

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -424,11 +424,7 @@ public class Fido2Tests
 
         var credId = "F1-3C-7F-08-3C-A2-29-E0-B4-03-E8-87-34-6E-FC-7F-98-53-10-3A-30-91-75-67-39-7A-D1-D8-AF-87-04-61-87-EF-95-31-85-60-F3-5A-1A-2A-CF-7D-B0-1D-06-B9-69-F9-AB-F4-EC-F3-07-3E-CF-0F-71-E8-84-E8-41-20";
         var allowedCreds = new List<PublicKeyCredentialDescriptor>() {
-            new PublicKeyCredentialDescriptor()
-            {
-                Id = Convert.FromHexString(credId.Replace("-", "")),
-                Type = PublicKeyCredentialType.PublicKey
-            }
+            new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, Convert.FromHexString(credId.Replace("-", "")))
         };
 
         // assertion
@@ -1033,11 +1029,7 @@ public class Fido2Tests
             Origins = new HashSet<string> { rp },
         });
         var existingCredentials = new List<PublicKeyCredentialDescriptor>();
-        var cred = new PublicKeyCredentialDescriptor
-        {
-            Type = PublicKeyCredentialType.PublicKey,
-            Id = new byte[] { 0xf1, 0xd0 }
-        };
+        var cred = new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PublicKey, new byte[] { 0xf1, 0xd0 });
         existingCredentials.Add(cred);
 
         var options = lib.GetAssertionOptions(existingCredentials, null, null);

--- a/Tests/Fido2.Ctap2.Tests/Commands/AuthenticatorGetAssertionCommandTests.cs
+++ b/Tests/Fido2.Ctap2.Tests/Commands/AuthenticatorGetAssertionCommandTests.cs
@@ -10,16 +10,10 @@ public class AuthenticatorGetAssertionCommandTests
         var request = new AuthenticatorGetAssertionCommand(
             rpId: "example.com",
             clientDataHash: Convert.FromHexString("687134968222ec17202e42505f8ed2b16ae22f16bb05b88c25db9e602645f141"),
-            allowList: new []
+            allowList: new PublicKeyCredentialDescriptor[]
             {
-                new  PublicKeyCredentialDescriptor {
-                    Id = Convert.FromHexString("f22006de4f905af68a43942f024f2a5ece603d9c6d4b3df8be08ed01fc442646d034858ac75bed3fd580bf9808d94fcbee82b9b2ef6677af0adcc35852ea6b9e"),
-                    Type = PublicKeyCredentialType.PublicKey
-                },
-                new  PublicKeyCredentialDescriptor {
-                    Id = Convert.FromHexString("0303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303"),
-                    Type = PublicKeyCredentialType.PublicKey
-                }
+                new(Convert.FromHexString("f22006de4f905af68a43942f024f2a5ece603d9c6d4b3df8be08ed01fc442646d034858ac75bed3fd580bf9808d94fcbee82b9b2ef6677af0adcc35852ea6b9e")),
+                new(Convert.FromHexString("0303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303"))
             },
             options: new AuthenticatorGetAssertionOptions { UserVerification = true }
                      

--- a/Tests/Fido2.Ctap2.Tests/Commands/AuthenticatorMakeCredentialCommandTests.cs
+++ b/Tests/Fido2.Ctap2.Tests/Commands/AuthenticatorMakeCredentialCommandTests.cs
@@ -8,15 +8,14 @@ public class AuthenticatorMakeCredentialCommandTests
     public void GetPayload()
     {
         var request = new AuthenticatorMakeCredentialCommand(
-            clientDataHash: Convert.FromHexString("687134968222ec17202e42505f8ed2b16ae22f16bb05b88c25db9e602645f141"),
-            rpEntity: new PublicKeyCredentialRpEntity(id: "example.com", name: "Acme", null),
-            user: new PublicKeyCredentialUserEntity {
-                    Id          = Convert.FromHexString("3082019330820138a0030201023082019330820138a003020102308201933082"),
-                    Icon        = "https://pics.example.com/00/p/aBjjjpqPb.png",
-                    Name        = "johnpsmith@example.com",
-                    DisplayName = "John P. Smith"
-                            
-            },
+            clientDataHash : Convert.FromHexString("687134968222ec17202e42505f8ed2b16ae22f16bb05b88c25db9e602645f141"),
+            rpEntity       : new PublicKeyCredentialRpEntity(id: "example.com", name: "Acme", null),
+            user           : new PublicKeyCredentialUserEntity(
+                                id          : Convert.FromHexString("3082019330820138a0030201023082019330820138a003020102308201933082"),
+                                icon        : "https://pics.example.com/00/p/aBjjjpqPb.png",
+                                name        : "johnpsmith@example.com",
+                                displayName : "John P. Smith"
+                            ),            
             pubKeyCredParams: new[] { 
                 new PubKeyCredParam(COSE.Algorithm.ES256), 
                 new PubKeyCredParam(COSE.Algorithm.RS256)


### PR DESCRIPTION
The purpose of this PR is to start a discussion on whether we want to introduce immutable models into the library for the 4.0 release. If we decide to move forward on this, this would be done after the Passkeys merge to prevent conflicts. 

Immutable models ensure:

- instances are validated at construction time according to the specification
- instances aren't modified and remain valid for their entire lifetime
- the instances can be safely reused

Apple & Android also have exposed their Fido2 implementation over immutable models. 

for example:

https://developers.google.com/android/reference/com/google/android/gms/fido/fido2/api/common/PublicKeyCredentialUserEntity#getIcon()

https://developer.apple.com/documentation/authenticationservices/asauthorizationsecuritykeypublickeycredentialdescriptor