### PR TITLE
SourceLink consolidation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+<!-- Root build props for the whole solution -->
 <Project>
   <!-- Package Metadata -->
   <PropertyGroup>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -7,7 +7,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Projects inside "./src" should generate packages -->

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,3 +1,4 @@
+<!-- Build props for the libraries (anything under Src/) -->
 <Project>
   <Import Project="..\Directory.Build.props"/>
 

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -11,10 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/Src/Fido2.Ctap2/Fido2.Ctap2.csproj
+++ b/Src/Fido2.Ctap2/Fido2.Ctap2.csproj
@@ -10,9 +10,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Fido2\Fido2.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
-
 </Project>

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -10,8 +10,4 @@
   <ItemGroup>
     <Compile Remove="IMetadataService.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
 </Project>

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -31,8 +31,4 @@
     -->
     <Content Include="build/fido2.targets" PackagePath="build/" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
 </Project>

--- a/fido2-net-lib.sln
+++ b/fido2-net-lib.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		Src\Directory.Build.props = Src\Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fido2.Models", "Src\Fido2.Models\Fido2.Models.csproj", "{08AA0431-3BBF-49EF-8DEF-5433B3068D92}"
@@ -21,7 +22,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fido2.AspNet", "Src\Fido2.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fido2.Ctap2", "Src\Fido2.Ctap2\Fido2.Ctap2.csproj", "{5B998DB8-6E96-4012-B524-32E113815059}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fido2.Ctap2.Tests", "Tests\Fido2.Ctap2.Tests\Fido2.Ctap2.Tests.csproj", "{BB3D1D09-1506-4DF9-8211-8B284E12B0F8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fido2.Ctap2.Tests", "Tests\Fido2.Ctap2.Tests\Fido2.Ctap2.Tests.csproj", "{BB3D1D09-1506-4DF9-8211-8B284E12B0F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
So I just spent hours figuring out why my build wanted to include some beta version of SourceLink and why all the references in the libraries are set to "Update". 

Turns out there's another Directory.Build.props I didn't see because I didn't look in the actual file system.  
This change makes it more obvious what's going on and also updates the SourceLink reference in the Directory.Build.props so the projects don't have to do it themselves.

Edit: The GUID change is just VS migrating from the old project system to the new one (see https://github.com/dotnet/project-system/issues/3079)