### PR TITLE
Support for PRF Extension

### DIFF
--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
@@ -61,5 +61,11 @@ public sealed class AuthenticationExtensionsClientInputs
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("prf")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AuthenticationExtensionsPRFInputs PRF { get; set; }
 }
 

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
@@ -61,12 +61,13 @@ public sealed class AuthenticationExtensionsClientInputs
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
+    
     /// <summary>
     /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.
     /// https://w3c.github.io/webauthn/#prf-extension
     /// </summary>
     [JsonPropertyName("prf")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public AuthenticationExtensionsPRFInputs PRF { get; set; }
+    public AuthenticationExtensionsPRFInputs? PRF { get; set; }
 }
 

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
@@ -62,7 +62,8 @@ public sealed class AuthenticationExtensionsClientInputs
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
     /// <summary>
-    /// 
+    /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.
+    /// https://w3c.github.io/webauthn/#prf-extension
     /// </summary>
     [JsonPropertyName("prf")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -58,6 +58,8 @@ public class AuthenticationExtensionsClientOutputs
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
     /// 
+    /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.
+    /// https://w3c.github.io/webauthn/#prf-extension
     /// </summary>
     [JsonPropertyName("prf")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -57,4 +57,9 @@ public class AuthenticationExtensionsClientOutputs
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
+    /// 
+    /// </summary>
+    [JsonPropertyName("prf")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AuthenticationExtensionsPRFOutputs? PRF { get; set; }
 }

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -57,7 +57,8 @@ public class AuthenticationExtensionsClientOutputs
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? CredProps { get; set; }
-    /// 
+    
+    /// <summary>
     /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.
     /// https://w3c.github.io/webauthn/#prf-extension
     /// </summary>

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFInputs.cs
@@ -4,17 +4,19 @@ using System.Text.Json.Serialization;
 namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// 
+/// This is a dictionary containing the PRF extension input values
 /// </summary>
 public sealed class AuthenticationExtensionsPRFInputs
 {
     /// <summary>
-    /// 
+    /// Inputs on which to evaluate PRF.
+    /// https://w3c.github.io/webauthn/#dom-authenticationextensionsprfinputs-eval
     /// </summary>
     [JsonPropertyName("eval")]
     public AuthenticationExtensionsPRFValues Eval { get; set; }
     /// <summary>
-    /// 
+    /// A record mapping base64url encoded credential IDs to PRF inputs to evaluate for that credential.
+    /// https://w3c.github.io/webauthn/#dom-authenticationextensionsprfinputs-evalbycredential
     /// </summary>
     [JsonPropertyName("evalByCredential")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFInputs.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Fido2NetLib.Objects;
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class AuthenticationExtensionsPRFInputs
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("eval")]
+    public AuthenticationExtensionsPRFValues Eval { get; set; }
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("evalByCredential")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public KeyValuePair<string, AuthenticationExtensionsPRFValues>? EvalByCredential { get; set; }
+}

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFOutputs.cs
@@ -3,17 +3,17 @@
 namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// 
+/// This is a dictionary containing the PRF extension output values
 /// </summary>
 public sealed class AuthenticationExtensionsPRFOutputs
 {
     /// <summary>
-    /// 
+    /// If PRFs are available for use with the created credential.
     /// </summary>
     [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }
     /// <summary>
-    /// 
+    /// The results of evaluating the PRF inputs.
     /// </summary>
     [JsonPropertyName("results")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFOutputs.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Fido2NetLib.Objects;
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class AuthenticationExtensionsPRFOutputs
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("results")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AuthenticationExtensionsPRFValues Results { get; set; }
+}

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFValues.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFValues.cs
@@ -3,18 +3,18 @@
 namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// 
+/// Evaluated PRF values.
 /// </summary>
 public sealed class AuthenticationExtensionsPRFValues
 {
     /// <summary>
-    /// 
+    /// salt1 value to the PRF evaluation.
     /// </summary>
     [JsonPropertyName("first")]
     [JsonConverter(typeof(Base64UrlConverter))]
     public byte[] First { get; set; }
     /// <summary>
-    /// 
+    /// salt2 value to the PRF evaluation.
     /// </summary>
     [JsonPropertyName("second")]
     [JsonConverter(typeof(Base64UrlConverter))]

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFValues.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsPRFValues.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Fido2NetLib.Objects;
+
+/// <summary>
+/// 
+/// </summary>
+public sealed class AuthenticationExtensionsPRFValues
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("first")]
+    [JsonConverter(typeof(Base64UrlConverter))]
+    public byte[] First { get; set; }
+    /// <summary>
+    /// 
+    /// </summary>
+    [JsonPropertyName("second")]
+    [JsonConverter(typeof(Base64UrlConverter))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public byte[] Second { get; set; }
+}
+

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -20,7 +20,7 @@ public class AuthenticatorResponse
     [InlineData("https://www.passwordless.dev:443", "https://www.passwordless.dev:443")]
     [InlineData("https://www.passwordless.dev", "https://www.passwordless.dev:443")]
     [InlineData("https://www.passwordless.dev:443", "https://www.passwordless.dev")]
-    [InlineData("https://www.passwordless.dev:443/foo/bar.html","https://www.passwordless.dev:443/foo/bar.html")]
+    [InlineData("https://www.passwordless.dev:443/foo/bar.html", "https://www.passwordless.dev:443/foo/bar.html")]
     [InlineData("https://www.passwordless.dev:443/foo/bar.html", "https://www.passwordless.dev:443/bar/foo.html")]
     [InlineData("https://www.passwordless.dev:443/foo/bar.html", "https://www.passwordless.dev/bar/foo.html")]
     [InlineData("https://www.passwordless.dev:443/foo/bar.html", "https://www.passwordless.dev")]
@@ -38,7 +38,7 @@ public class AuthenticatorResponse
     [InlineData("lorem://ipsum:1234", "lorem://ipsum:1234")]
     [InlineData("lorem://ipsum:9876/sit", "lorem://ipsum:9876/sit")]
     [InlineData("foo://bar:321/path/", "foo://bar:321/path/")]
-    [InlineData("foo://bar:321/path","foo://bar:321/path")]
+    [InlineData("foo://bar:321/path", "foo://bar:321/path")]
     [InlineData("http://[0:0:0:0:0:0:0:1]", "http://[0:0:0:0:0:0:0:1]")]
     [InlineData("http://[0:0:0:0:0:0:0:1]", "http://[0:0:0:0:0:0:0:1]:80")]
     [InlineData("https://[0:0:0:0:0:0:0:1]", "https://[0:0:0:0:0:0:0:1]")]
@@ -55,7 +55,7 @@ public class AuthenticatorResponse
             acd
         ).ToByteArray();
 
-        byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new 
+        byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
         {
             type = "webauthn.create",
             challenge = challenge,
@@ -257,6 +257,15 @@ public class AuthenticatorResponse
                         4 // USER_VERIFY_PASSCODE_INTERNAL
                     },
                 },
+                PRF = new AuthenticationExtensionsPRFOutputs
+                {
+                    Enabled = true,
+                    Results = new AuthenticationExtensionsPRFValues
+                    {
+                        First = new byte[] { 0xf1, 0xd0 },
+                        Second = new byte[] { 0xf1, 0xd0 }
+                    }
+                }
             }
         };
         Assert.Equal(PublicKeyCredentialType.PublicKey, rawResponse.Type);
@@ -267,8 +276,11 @@ public class AuthenticatorResponse
         Assert.True(rawResponse.Extensions.AppID);
         Assert.True(rawResponse.Extensions.AuthenticatorSelection);
         Assert.Equal(rawResponse.Extensions.Extensions, new string[] { "foo", "bar" });
+        Assert.True(rawResponse.Extensions.PRF.Enabled);
         Assert.Equal("test", rawResponse.Extensions.Example);
         Assert.Equal((ulong)4, rawResponse.Extensions.UserVerificationMethod[0][0]);
+        Assert.True(rawResponse.Extensions.PRF.Results.First.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
+        Assert.True(rawResponse.Extensions.PRF.Results.Second.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
     }
 
     [Fact]
@@ -357,7 +369,7 @@ public class AuthenticatorResponse
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
-        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new 
+        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
         {
             Type = "webauthn.get",
             Challenge = challenge,
@@ -429,7 +441,8 @@ public class AuthenticatorResponse
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
-        byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new {
+        byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
+        {
             type = "webauthn.create",
             challenge = challenge,
             origin = rp,
@@ -498,7 +511,8 @@ public class AuthenticatorResponse
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
-        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new {
+        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
+        {
             type = "webauthn.create",
             challenge = challenge,
             origin = rp,
@@ -652,7 +666,7 @@ public class AuthenticatorResponse
             null
         ).ToByteArray();
 
-        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new 
+        var clientDataJson = JsonSerializer.SerializeToUtf8Bytes(new
         {
             type = "webauthn.create",
             challenge = challenge,
@@ -972,7 +986,7 @@ public class AuthenticatorResponse
             challenge = challenge,
             origin = rp,
         });
-               
+
         var rawResponse = new AuthenticatorAttestationRawResponse
         {
             Type = PublicKeyCredentialType.PublicKey,
@@ -1224,6 +1238,15 @@ public class AuthenticatorResponse
                         4 // USER_VERIFY_PASSCODE_INTERNAL
                     },
                 },
+                PRF = new AuthenticationExtensionsPRFOutputs
+                {
+                    Enabled = true,
+                    Results = new AuthenticationExtensionsPRFValues
+                    {
+                        First = new byte[] { 0xf1, 0xd0 },
+                        Second = new byte[] { 0xf1, 0xd0 }
+                    }
+                }
             }
         };
         Assert.Equal(PublicKeyCredentialType.PublicKey, assertionResponse.Type);
@@ -1238,6 +1261,8 @@ public class AuthenticatorResponse
         Assert.Equal(assertionResponse.Extensions.Extensions, new string[] { "foo", "bar" });
         Assert.Equal("test", assertionResponse.Extensions.Example);
         Assert.Equal((ulong)4, assertionResponse.Extensions.UserVerificationMethod[0][0]);
+        Assert.True(assertionResponse.Extensions.PRF.Results.First.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
+        Assert.True(assertionResponse.Extensions.PRF.Results.Second.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
     }
 
     [Fact]

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -276,9 +276,9 @@ public class AuthenticatorResponse
         Assert.True(rawResponse.Extensions.AppID);
         Assert.True(rawResponse.Extensions.AuthenticatorSelection);
         Assert.Equal(rawResponse.Extensions.Extensions, new string[] { "foo", "bar" });
-        Assert.True(rawResponse.Extensions.PRF.Enabled);
         Assert.Equal("test", rawResponse.Extensions.Example);
         Assert.Equal((ulong)4, rawResponse.Extensions.UserVerificationMethod[0][0]);
+        Assert.True(rawResponse.Extensions.PRF.Enabled);
         Assert.True(rawResponse.Extensions.PRF.Results.First.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
         Assert.True(rawResponse.Extensions.PRF.Results.Second.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
     }
@@ -1261,6 +1261,7 @@ public class AuthenticatorResponse
         Assert.Equal(assertionResponse.Extensions.Extensions, new string[] { "foo", "bar" });
         Assert.Equal("test", assertionResponse.Extensions.Example);
         Assert.Equal((ulong)4, assertionResponse.Extensions.UserVerificationMethod[0][0]);
+        Assert.True(assertionResponse.Extensions.PRF.Enabled);
         Assert.True(assertionResponse.Extensions.PRF.Results.First.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
         Assert.True(assertionResponse.Extensions.PRF.Results.Second.SequenceEqual(new byte[] { 0xf1, 0xd0 }));
     }


### PR DESCRIPTION
This PR adds support for the [PRF extension](https://w3c.github.io/webauthn/#dictdef-authenticationextensionsprfvalues) to the extension client input/output models. 

All existing tests pass, but I am not sure if/what new tests need to be added for PRF support in this library.