### PR TITLE
Fix demo project starting exception: change TargetFrameworks to TargetFramework

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
     <RootNamespace>Fido2Demo</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Before my suggested change, on performing `dotnet run` you get a framework version specification error.

![image](https://github.com/passwordless-lib/fido2-net-lib/assets/36074789/4458197f-4b03-4e6e-b337-94dc9ec8b303)

This change makes the demo project a "clone&run" project, with zero extra effort.

The change is based on this response:
https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/25#issuecomment-509359412