### PR TITLE
Fix AuthenticationExtensionsClientInputs Example json prop name for conformance tests

### DIFF
--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
@@ -10,7 +10,7 @@ public sealed class AuthenticationExtensionsClientInputs
     /// <summary>
     /// This extension allows for passing of conformance tests
     /// </summary>
-    [JsonPropertyName("example.extension")]
+    [JsonPropertyName("example.extension.bool")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public object Example { get; set; }
 


### PR DESCRIPTION
expected value:
`{"example.extension.bool":true}`

Actual current value:
`{"example.extension":true}`

This fixes the first test:
`[Server-ServerPublicKeyCredentialCreationOptions-Req-1 Test server generating ServerPublicKeyCredentialCreationOptionsRequest](https://github.com/Applications/FIDO%20Alliance%20-%20Certification%20Conformance%20Testing%20Tools.app/Contents/Resources/app.asar/app/index.html?grep=%0A%0A%20%20%20%20%20%20%20%20Server-ServerPublicKeyCredentialCreationOptions-Req-1%0A%0A%20%20%20%20%20%20%20%20Test%20server%20generating%20ServerPublicKeyCredentialCreationOptionsRequest%0A%0A%20%20%20%20)`