### PR TITLE
Add CredentialPropertiesOuput (RK Support)

### DIFF
--- a/Demo/Controller.cs
+++ b/Demo/Controller.cs
@@ -121,7 +121,7 @@ public class MyController : Controller
             {
                 Type = success.Result.Type,
                 Id = success.Result.Id,
-                Descriptor = new PublicKeyCredentialDescriptor(success.Result.CredentialId),
+                Descriptor = new PublicKeyCredentialDescriptor(success.Result.Id),
                 PublicKey = success.Result.PublicKey,
                 UserHandle = success.Result.User.Id,
                 SignCount = success.Result.Counter,

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -56,7 +56,7 @@ public class AuthenticationExtensionsClientOutputs
     /// </summary>
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? CredProps { get; set; }
+    public CredentialPropertiesOutput? CredProps { get; set; }
     
     /// <summary>
     /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.

--- a/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
+++ b/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System.Text.Json.Serialization;
+
+namespace Fido2NetLib.Objects;
+
+/// <summary>
+/// This client registration extension facilitates reporting certain credential properties known by the client to the requesting WebAuthn Relying Party upon creation of a public key credential source as a result of a registration ceremony.
+/// </summary>
+public class CredentialPropertiesOutput
+{
+    /// <summary>
+    /// This OPTIONAL property, known abstractly as the resident key credential property (i.e., client-side discoverable credential property), is a Boolean value indicating whether the PublicKeyCredential returned as a result of a registration ceremony is a client-side discoverable credential. If rk is true, the credential is a discoverable credential. if rk is false, the credential is a server-side credential. If rk is not present, it is not known whether the credential is a discoverable credential or a server-side credential.
+    /// </summary>
+    [JsonPropertyName("rk")]
+    public bool Rk { get; set; }
+}


### PR DESCRIPTION
Browsers respond with a a object.

- Add CredentialPropertiesOutput
- Use .ID instead of null CredentialId
