### PR TITLE
[WIP] Make AuthenticatorData immutable and strongly type throughout library

### DIFF
--- a/Src/Fido2.Models/Objects/AttestationVerificationSuccess.cs
+++ b/Src/Fido2.Models/Objects/AttestationVerificationSuccess.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 
 namespace Fido2NetLib.Objects;

--- a/Src/Fido2/AttestationFormat/AndroidKey.cs
+++ b/Src/Fido2/AttestationFormat/AndroidKey.cs
@@ -186,7 +186,7 @@ internal sealed class AndroidKey : AttestationVerifier
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Invalid android key attestation signature");
 
         // 3. Verify that the public key in the first certificate in x5c matches the credentialPublicKey in the attestedCredentialData in authenticatorData.
-        if (!AuthData.AttestedCredentialData.CredentialPublicKey.Verify(Data, sig))
+        if (!AuthData.AttestedCredentialData!.CredentialPublicKey.Verify(Data, sig))
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Incorrect credentialPublicKey in android key attestation");
 
         // 4. Verify that the attestationChallenge field in the attestation certificate extension data is identical to clientDataHash

--- a/Src/Fido2/AttestationFormat/Apple.cs
+++ b/Src/Fido2/AttestationFormat/Apple.cs
@@ -81,7 +81,7 @@ internal sealed class Apple : AttestationVerifier
         var cpk = new CredentialPublicKey(credCert, coseAlg);
 
         // Finally, compare byte sequence of CredentialPublicKey built from credCert with byte sequence of CredentialPublicKey from AttestedCredentialData from authData
-        if (!cpk.GetBytes().AsSpan().SequenceEqual(AuthData.AttestedCredentialData.CredentialPublicKey.GetBytes()))
+        if (!cpk.GetBytes().AsSpan().SequenceEqual(AuthData.AttestedCredentialData!.CredentialPublicKey.GetBytes()))
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Credential public key in Apple attestation does not match subject public key of credCert");
 
         // 7. If successful, return implementation-specific values representing attestation type Anonymous CA and attestation trust path x5c.

--- a/Src/Fido2/AttestationFormat/AppleAppAttest.cs
+++ b/Src/Fido2/AttestationFormat/AppleAppAttest.cs
@@ -64,7 +64,7 @@ internal sealed class AppleAppAttest : AttestationVerifier
         chain.ChainPolicy.ExtraStore.Add(intermediateCert);
 
         X509Certificate2 credCert = new((byte[])x5cArray[0]);
-        if (AuthData.AttestedCredentialData.AaGuid.Equals(devAaguid))
+        if (AuthData.AttestedCredentialData!.AaGuid.Equals(devAaguid))
         {
             // Allow expired leaf cert in development environment
             chain.ChainPolicy.VerificationTime = credCert.NotBefore.AddSeconds(1);

--- a/Src/Fido2/AttestationFormat/AttestationVerifier.cs
+++ b/Src/Fido2/AttestationFormat/AttestationVerifier.cs
@@ -14,7 +14,7 @@ namespace Fido2NetLib;
 public abstract class AttestationVerifier
 {
     private protected CborMap _attStmt;
-    private protected byte[] _authenticatorData;
+    private protected AuthenticatorData _authenticatorData;
     private protected byte[] _clientDataHash;
 
 #nullable enable
@@ -23,11 +23,11 @@ public abstract class AttestationVerifier
 
     internal CborObject? EcdaaKeyId => _attStmt["ecdaaKeyId"];
 
-    internal AuthenticatorData AuthData => new (_authenticatorData);
+    internal AuthenticatorData AuthData => _authenticatorData;
 
-    internal CborMap CredentialPublicKey => AuthData.AttestedCredentialData.CredentialPublicKey.GetCborObject();
+    internal CborMap CredentialPublicKey => AuthData.AttestedCredentialData!.CredentialPublicKey.GetCborObject();
 
-    internal byte[] Data => DataHelper.Concat(_authenticatorData, _clientDataHash);
+    internal byte[] Data => DataHelper.Concat(_authenticatorData.ToByteArray(), _clientDataHash);
 
     internal bool TryGetVer([NotNullWhen(true)] out string? ver)
     {
@@ -127,7 +127,7 @@ public abstract class AttestationVerifier
 
 #nullable disable
 
-    public virtual (AttestationType, X509Certificate2[]) Verify(CborMap attStmt, byte[] authenticatorData, byte[] clientDataHash)
+    public virtual (AttestationType, X509Certificate2[]) Verify(CborMap attStmt, AuthenticatorData authenticatorData, byte[] clientDataHash)
     {
         _attStmt = attStmt;
         _authenticatorData = authenticatorData;

--- a/Src/Fido2/AttestationFormat/FidoU2f.cs
+++ b/Src/Fido2/AttestationFormat/FidoU2f.cs
@@ -14,7 +14,7 @@ namespace Fido2NetLib
         public override (AttestationType, X509Certificate2[]) Verify()
         {
             // verify that aaguid is 16 empty bytes (note: required by fido2 conformance testing, could not find this in spec?)
-            if (AuthData.AttestedCredentialData.AaGuid.CompareTo(Guid.Empty) != 0)
+            if (AuthData.AttestedCredentialData!.AaGuid.CompareTo(Guid.Empty) != 0)
                 throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Aaguid was not empty parsing fido-u2f atttestation statement");
 
             // https://www.w3.org/TR/webauthn/#fido-u2f-attestation

--- a/Src/Fido2/AttestationFormat/Packed.cs
+++ b/Src/Fido2/AttestationFormat/Packed.cs
@@ -108,7 +108,7 @@ internal sealed class Packed : AttestationVerifier
             // 2c. If attestnCert contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) verify that the value of this extension matches the aaguid in authenticatorData
             if (aaguid != null)
             {
-                if (AttestedCredentialData.FromBigEndian(aaguid).CompareTo(AuthData.AttestedCredentialData.AaGuid) != 0)
+                if (AttestedCredentialData.FromBigEndian(aaguid).CompareTo(AuthData.AttestedCredentialData!.AaGuid) != 0)
                     throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "aaguid present in packed attestation cert exts but does not match aaguid from authData");
             }
 
@@ -137,7 +137,7 @@ internal sealed class Packed : AttestationVerifier
         else
         {
             // 4a. Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData
-            if (!AuthData.AttestedCredentialData.CredentialPublicKey.IsSameAlg(alg))
+            if (!AuthData.AttestedCredentialData!.CredentialPublicKey.IsSameAlg(alg))
                 throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Algorithm mismatch between credential public key and authenticator data in self attestation statement");
 
             // 4b. Verify that sig is a valid signature over the concatenation of authenticatorData and 

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -197,7 +197,7 @@ internal sealed class Tpm : AttestationVerifier
             // 5c. If aikCert contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) verify that the value of this extension matches the aaguid in authenticatorData
             if (AaguidFromAttnCertExts(aikCert.Extensions) is byte[] aaguid &&
                 (!aaguid.AsSpan().SequenceEqual(Guid.Empty.ToByteArray())) &&
-                (AttestedCredentialData.FromBigEndian(aaguid).CompareTo(AuthData.AttestedCredentialData.AaGuid) != 0))
+                (AttestedCredentialData.FromBigEndian(aaguid).CompareTo(AuthData.AttestedCredentialData!.AaGuid) != 0))
             {
                 throw new Fido2VerificationException($"aaguid malformed, expected {AuthData.AttestedCredentialData.AaGuid}, got {new Guid(aaguid)}");
             }

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -68,7 +67,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
             AttestationObject = new ParsedAttestationObject(
                 fmt      : (string)cborAttestation["fmt"],
                 attStmt  : (CborMap)cborAttestation["attStmt"],
-                authData : (byte[])cborAttestation["authData"]
+                authData : AuthenticatorData.Parse((byte[])cborAttestation["authData"])
             )
         };
     }
@@ -103,7 +102,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         if (Raw.Type != PublicKeyCredentialType.PublicKey)
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestationResponse, "AttestationResponse type must be 'public-key'");
 
-        var authData = new AuthenticatorData(AttestationObject.AuthData);
+        var authData = AttestationObject.AuthData;
 
         // 10. Let hash be the result of computing a hash over response.clientDataJSON using SHA-256.
         byte[] clientDataHash = SHA256.HashData(Raw.Response.ClientDataJson);
@@ -235,7 +234,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
     /// <see cref="https://w3c.github.io/webauthn/#sctn-device-publickey-extension-verification-create"/> 
     private async Task<byte[]> DevicePublicKeyRegistrationAsync(
         AuthenticationExtensionsClientOutputs clientExtensionResults,
-        byte[] authData,
+        AuthenticatorData authData,
         byte[] hash
         )
     {
@@ -247,7 +246,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         DevicePublicKeyAuthenticatorOutput devicePublicKeyAuthenticatorOutput = new(attObjForDevicePublicKey.AuthenticatorOutput);
 
         // 3. Verify that signature is a valid signature over the assertion signature input (i.e. authData and hash) by the device public key dpk. 
-        if (!devicePublicKeyAuthenticatorOutput.DevicePublicKey.Verify(DataHelper.Concat(authData, hash), attObjForDevicePublicKey.Signature))
+        if (!devicePublicKeyAuthenticatorOutput.DevicePublicKey.Verify(DataHelper.Concat(authData.ToByteArray(), hash), attObjForDevicePublicKey.Signature))
             throw new Fido2VerificationException(Fido2ErrorCode.InvalidSignature, Fido2ErrorMessages.InvalidSignature);
 
         // 4. Optionally, if attestation was requested and the Relying Party wishes to verify it, verify that attStmt is a correct attestation statement, conveying a valid attestation signature,
@@ -256,7 +255,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         var verifier = AttestationVerifier.Create(devicePublicKeyAuthenticatorOutput.Fmt);
 
         // https://w3c.github.io/webauthn/#sctn-device-publickey-attestation-calculations
-        (var attType, var trustPath) = verifier.Verify(devicePublicKeyAuthenticatorOutput.AttStmt, devicePublicKeyAuthenticatorOutput.AuthData, devicePublicKeyAuthenticatorOutput.Hash);
+        (var attType, var trustPath) = verifier.Verify(devicePublicKeyAuthenticatorOutput.AttStmt, AuthenticatorData.Parse(devicePublicKeyAuthenticatorOutput.AuthData), devicePublicKeyAuthenticatorOutput.Hash);
 
         // 5. Complete the steps from § 7.1 Registering a New Credential and, if those steps are successful,
         // store the aaguid, dpk, scope, fmt, attStmt values indexed to the credential.id in the user account.
@@ -335,7 +334,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
     /// </summary>
     public sealed class ParsedAttestationObject
     {
-        public ParsedAttestationObject(string fmt, CborMap attStmt, byte[] authData)
+        public ParsedAttestationObject(string fmt, CborMap attStmt, AuthenticatorData authData)
         {
             Fmt = fmt;
             AttStmt = attStmt;
@@ -346,6 +345,6 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         
         public CborMap AttStmt { get; }
 
-        public byte[] AuthData { get; }
+        public AuthenticatorData AuthData { get; }
     }
 }

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -25,7 +25,8 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
     private IMetadataService _metadataService;
     private CancellationToken _cancellationToken;
     private Fido2Configuration _config;
-    private AuthenticatorAttestationResponse(byte[] clientDataJson) 
+
+    private AuthenticatorAttestationResponse(byte[] clientDataJson)
         : base(clientDataJson)
     {
     }

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="NSec.Cryptography" Version="22.4.0" />
     <PackageReference Include="System.Formats.Cbor" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Fido2/Objects/AuthenticatorData.cs
+++ b/Src/Fido2/Objects/AuthenticatorData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 
 using Fido2NetLib.Cbor;
 using Fido2NetLib.Exceptions;
@@ -84,12 +85,14 @@ public sealed class AuthenticatorData
     /// HasAttestedCredentialData indicates that the authenticator added attested credential data to the authenticator data.
     /// <see cref="https://www.w3.org/TR/webauthn/#attested-credential-data"/>
     /// </summary>
+    [MemberNotNullWhen(true, nameof(AttestedCredentialData))]
     public bool HasAttestedCredentialData => _flags.HasFlag(AuthenticatorFlags.AT);
 
     /// <summary>
     /// HasExtensionsData indicates that the authenticator added extension data to the authenticator data.
     /// <see cref="https://www.w3.org/TR/webauthn/#authdataextensions"/>
     /// </summary>
+    [MemberNotNullWhen(true, nameof(Extensions))]
     public bool HasExtensionsData => _flags.HasFlag(AuthenticatorFlags.ED);
 
     private byte[]? _data = null;

--- a/Src/Fido2/Objects/AuthenticatorData.cs
+++ b/Src/Fido2/Objects/AuthenticatorData.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System;
+﻿using System;
 using System.Buffers;
 
 using Fido2NetLib.Cbor;
@@ -18,10 +16,35 @@ public sealed class AuthenticatorData
 
     private const int SHA256HashLenBytes = 32; // 256 bits, 8 bits per byte
 
+    public AuthenticatorData(byte[] rpIdHash, AuthenticatorFlags flags, uint signCount, AttestedCredentialData? acd, Extensions? exts = null)
+    {
+        RpIdHash = rpIdHash;
+        _flags = flags;
+        SignCount = signCount;
+        AttestedCredentialData = acd;
+        Extensions = exts;
+    }
+
     /// <summary>
     /// SHA-256 hash of the RP ID the credential is scoped to.
     /// </summary>
-    public byte[] RpIdHash;
+    public byte[] RpIdHash { get; }
+
+    /// <summary>
+    /// Signature counter, 32-bit unsigned big-endian integer. 
+    /// </summary>
+    public uint SignCount { get; }
+
+    /// <summary>
+    /// Attested credential data is a variable-length byte array added to the 
+    /// authenticator data when generating an attestation object for a given credential.
+    /// </summary>
+    public AttestedCredentialData? AttestedCredentialData { get; }
+
+    /// <summary>
+    /// Optional extensions to suit particular use cases.
+    /// </summary>
+    public Extensions? Extensions { get; }
 
     /// <summary>
     /// Flags contains information from the authenticator about the authentication 
@@ -69,77 +92,13 @@ public sealed class AuthenticatorData
     /// </summary>
     public bool HasExtensionsData => _flags.HasFlag(AuthenticatorFlags.ED);
 
-    /// <summary>
-    /// Signature counter, 32-bit unsigned big-endian integer. 
-    /// </summary>
-    public uint SignCount;
-
-    /// <summary>
-    /// Attested credential data is a variable-length byte array added to the 
-    /// authenticator data when generating an attestation object for a given credential.
-    /// </summary>
-    public AttestedCredentialData AttestedCredentialData;
-
-    /// <summary>
-    /// Optional extensions to suit particular use cases.
-    /// </summary>
-    public Extensions Extensions;
-
-    public AuthenticatorData(byte[] rpIdHash, AuthenticatorFlags flags, uint signCount, AttestedCredentialData acd, Extensions exts = null)
-    {
-        RpIdHash = rpIdHash;
-        _flags = flags;
-        SignCount = signCount;
-        AttestedCredentialData = acd;
-        Extensions = exts;
-    }
-
-    public AuthenticatorData(byte[] authData)
-    {
-        // Input validation
-        if (authData is null)
-            throw new Fido2VerificationException(Fido2ErrorCode.MissingAuthenticatorData, Fido2ErrorMessages.MissingAuthenticatorData);
-
-        if (authData.Length < MinLength)
-            throw new Fido2VerificationException(Fido2ErrorCode.InvalidAuthenticatorData, Fido2ErrorMessages.InvalidAuthenticatorData_TooShort);
-
-        // Input parsing
-        var reader = new MemoryReader(authData);
-
-        RpIdHash = reader.ReadBytes(SHA256HashLenBytes);
-
-        _flags = (AuthenticatorFlags)reader.ReadByte();
-
-        SignCount = reader.ReadUInt32BigEndian();
-
-        // Attested credential data is only present if the AT flag is set
-        if (HasAttestedCredentialData)
-        {
-            // Decode attested credential data, which starts at the next byte past the minimum length of the structure
-            AttestedCredentialData = new AttestedCredentialData(authData.AsMemory(reader.Position), out int bytesRead);
-
-            reader.Advance(bytesRead);
-        }
-
-        // Extensions data is only present if the ED flag is set
-        if (HasExtensionsData)
-        {
-            // Read the CBOR object
-            var ext = CborObject.Decode(authData.AsMemory(reader.Position), out int bytesRead);
-
-            reader.Advance(bytesRead);
-
-            // Encode the CBOR object back to a byte array
-            Extensions = new Extensions(ext.Encode());
-        }
-
-        // Ensure there are no remaining bytes left over after decoding the structure
-        if (reader.RemainingBytes != 0)
-            throw new Fido2VerificationException(Fido2ErrorCode.InvalidAuthenticatorData, "Leftover bytes decoding AuthenticatorData");            
-    }
+    private byte[]? _data = null;
 
     public byte[] ToByteArray()
     {
+        if (_data != null)
+            return _data;
+
         var writer = new ArrayBufferWriter<byte>(512);
 
         writer.Write(RpIdHash);
@@ -148,16 +107,65 @@ public sealed class AuthenticatorData
 
         writer.WriteUInt32BigEndian(SignCount);
 
-        if (HasAttestedCredentialData)
+        if (HasAttestedCredentialData && AttestedCredentialData != null)
         {
             AttestedCredentialData.WriteTo(writer);
         }
 
-        if (HasExtensionsData)
+        if (HasExtensionsData && Extensions != null)
         {
             writer.Write(Extensions.GetBytes());
         }
 
         return writer.WrittenSpan.ToArray();
+    }
+
+    public static AuthenticatorData Parse(byte[] data)
+    {
+        if (data is null)
+            throw new Fido2VerificationException(Fido2ErrorCode.MissingAuthenticatorData, Fido2ErrorMessages.MissingAuthenticatorData);
+
+        if (data.Length < MinLength)
+            throw new Fido2VerificationException(Fido2ErrorCode.InvalidAuthenticatorData, Fido2ErrorMessages.InvalidAuthenticatorData_TooShort);
+
+        // Input parsing
+        var reader = new MemoryReader(data);
+
+        byte[] rpIdHash = reader.ReadBytes(SHA256HashLenBytes);
+
+        var flags = (AuthenticatorFlags)reader.ReadByte();
+
+        var signCount = reader.ReadUInt32BigEndian();
+
+        AttestedCredentialData? attestedCredentialData = null;
+
+        // Attested credential data is only present if the AT flag is set
+        if (flags.HasFlag(AuthenticatorFlags.AT))
+        {
+            // Decode attested credential data, which starts at the next byte past the minimum length of the structure
+            attestedCredentialData = new AttestedCredentialData(data.AsMemory(reader.Position), out int bytesRead);
+
+            reader.Advance(bytesRead);
+        }
+
+        Extensions? extensions = null;
+
+        // Extensions data is only present if the ED flag is set
+        if (flags.HasFlag(AuthenticatorFlags.ED))
+        {
+            // Read the CBOR object
+            var ext = CborObject.Decode(data.AsMemory(reader.Position), out int bytesRead);
+
+            reader.Advance(bytesRead);
+
+            // Encode the CBOR object back to a byte array
+            extensions = new Extensions(ext.Encode());
+        }
+
+        // Ensure there are no remaining bytes left over after decoding the structure
+        if (reader.RemainingBytes != 0)
+            throw new Fido2VerificationException(Fido2ErrorCode.InvalidAuthenticatorData, "Leftover bytes decoding AuthenticatorData");
+
+        return new AuthenticatorData(rpIdHash, flags, signCount, attestedCredentialData, extensions) { _data = data };
     }
 }

--- a/Src/Fido2/Objects/CredentialIdUserHandleParams.cs
+++ b/Src/Fido2/Objects/CredentialIdUserHandleParams.cs
@@ -1,7 +1,7 @@
 ﻿namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// Paramters used for callback function
+/// Parameters used for callback function
 /// </summary>
 public sealed class IsUserHandleOwnerOfCredentialIdParams
 {   

--- a/Src/Fido2/Objects/CredentialIdUserParams.cs
+++ b/Src/Fido2/Objects/CredentialIdUserParams.cs
@@ -1,7 +1,7 @@
 ﻿namespace Fido2NetLib.Objects;
 
 /// <summary>
-/// Paramters used for callback function to check that the CredentialId is unique user
+/// Parameters used for callback function to check that the CredentialId is unique user
 /// </summary>
 public sealed class IsCredentialIdUniqueToUserParams
 {

--- a/Test/Asn1Tests.cs
+++ b/Test/Asn1Tests.cs
@@ -143,7 +143,7 @@ public class Asn1Tests
         Assert.True(element6_1.IsConstructed);
         Assert.Equal(TagClass.ContextSpecific, element6_1.TagClass);
         Assert.Equal(1, element6_1.TagValue);
-        Assert.Equal(1, element6_1.Sequence.Count);
+        Assert.Single(element6_1.Sequence);
 
         Assert.Equal(Asn1Tag.SetOf, element6_1_0.Tag);
 

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -260,7 +260,7 @@ public class Tpm : Fido2Tests.Attestation
                             unique // Unique
                         );
 
-                        byte[] data = Concat(_authData, _clientDataHash);
+                        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
                         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
 
@@ -385,7 +385,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
 
@@ -496,7 +496,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -594,7 +594,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
 
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -692,7 +692,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -797,7 +797,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -896,7 +896,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
 
@@ -995,7 +995,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1093,7 +1093,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1189,7 +1189,7 @@ public class Tpm : Fido2Tests.Attestation
             .Concat(BitConverter.GetBytes(exponent[0] + (exponent[1] << 8) + (exponent[2] << 16)))
             .ToArray();
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1287,7 +1287,7 @@ public class Tpm : Fido2Tests.Attestation
             Array.Empty<byte>() // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1387,7 +1387,7 @@ public class Tpm : Fido2Tests.Attestation
             unique.Reverse().ToArray() // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1485,7 +1485,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1600,7 +1600,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1714,7 +1714,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1829,7 +1829,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -1927,7 +1927,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2025,7 +2025,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2130,7 +2130,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2228,7 +2228,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2326,7 +2326,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2424,7 +2424,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2522,7 +2522,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2620,7 +2620,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2718,7 +2718,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2821,7 +2821,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -2919,7 +2919,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3017,7 +3017,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3115,7 +3115,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3213,7 +3213,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3311,7 +3311,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3412,7 +3412,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3510,7 +3510,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3608,7 +3608,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3706,7 +3706,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3804,7 +3804,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -3903,7 +3903,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4001,7 +4001,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4099,7 +4099,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4202,7 +4202,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4311,7 +4311,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4409,7 +4409,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4515,7 +4515,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4617,7 +4617,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4719,7 +4719,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4821,7 +4821,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -4924,7 +4924,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -5023,7 +5023,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -5121,7 +5121,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -5219,7 +5219,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -5333,7 +5333,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);
@@ -5431,7 +5431,7 @@ public class Tpm : Fido2Tests.Attestation
             unique // Unique
         );
 
-        byte[] data = Concat(_authData, _clientDataHash);
+        byte[] data = Concat(_authData.ToByteArray(), _clientDataHash);
 
         var hashAlg = CryptoUtils.HashAlgFromCOSEAlg(alg);
         byte[] hashedData = CryptoUtils.HashData(hashAlg, data);

--- a/Test/AuthenticatorDataTests.cs
+++ b/Test/AuthenticatorDataTests.cs
@@ -10,7 +10,7 @@ public class AuthenticatorDataTests
     public void AuthenticatorDataNull()
     {
         byte[] ad = null;
-        var ex = Assert.Throws<Fido2VerificationException>(() => new AuthenticatorData(ad));
+        var ex = Assert.Throws<Fido2VerificationException>(() => AuthenticatorData.Parse(ad));
         Assert.Equal(Fido2ErrorMessages.MissingAuthenticatorData, ex.Message);
     }
 
@@ -18,7 +18,7 @@ public class AuthenticatorDataTests
     public void AuthenticatorDataMinLen()
     {
         byte[] ad = new byte[36];
-        var ex = Assert.Throws<Fido2VerificationException>(() => new AuthenticatorData(ad));
+        var ex = Assert.Throws<Fido2VerificationException>(() => AuthenticatorData.Parse(ad));
         Assert.Equal("Authenticator data is less than the minimum structure length of 37", ex.Message);
     }
 
@@ -26,7 +26,7 @@ public class AuthenticatorDataTests
     public void AuthenticatorDataExtraBytes()
     {
         byte[] ad = Convert.FromHexString("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97634100000000000000000000000000000000000000000040ee726cb6daf874b4ac9ab5a76870777aca49d2e6bdaec276c2cfbddc115c34e3fae20fecff8c0b143be496b358720d0108de9d7548c92f10df0d206b78a40b03a501020326200121582050e028e71aac2683df256b14e7487b7364bbfe594fd0ac0623abc99048f5378f225820364cc49e05f849f381f23104208c9bc1880e899c7034721c52966b99793f578242");
-        var ex = Assert.Throws<Fido2VerificationException>(() => new AuthenticatorData(ad));
+        var ex = Assert.Throws<Fido2VerificationException>(() => AuthenticatorData.Parse(ad));
         Assert.Equal("Leftover bytes decoding AuthenticatorData", ex.Message);
     }
 }

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -365,7 +365,7 @@ public class AuthenticatorResponse
     }
 
     [Fact]
-    public void TestAuthenticatorAttestationResponseInvalidType()
+    public async Task TestAuthenticatorAttestationResponseInvalidType()
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
@@ -386,7 +386,7 @@ public class AuthenticatorResponse
                 AttestationObject = new CborMap {
                     { "fmt", "testing" },
                     { "attStmt", new CborMap() },
-                    { "authData", Array.Empty<byte>() }
+                    { "authData", new AuthenticatorData(new byte[32], default, 0, null, null).ToByteArray() }
                 }.Encode(),
                 ClientDataJson = clientDataJson
             },
@@ -430,8 +430,8 @@ public class AuthenticatorResponse
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
-        Assert.Equal("AttestationResponse type must be webauthn.create", ex.Result.Message);
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
+        Assert.Equal("AttestationResponse type must be webauthn.create", ex.Message);
     }
 
     [Theory]
@@ -458,7 +458,7 @@ public class AuthenticatorResponse
                 AttestationObject = new CborMap {
                     { "fmt", "testing" },
                     { "attStmt", new CborMap() },
-                    { "authData", Array.Empty<byte>() }
+                    { "authData", new AuthenticatorData(new byte[32], default, 0, null, null).ToByteArray() }
                 }.Encode(),
                 ClientDataJson = clientDataJson
             },
@@ -507,7 +507,7 @@ public class AuthenticatorResponse
     }
 
     [Fact]
-    public void TestAuthenticatorAttestationResponseInvalidRawType()
+    public async Task TestAuthenticatorAttestationResponseInvalidRawType()
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
@@ -528,7 +528,7 @@ public class AuthenticatorResponse
                 AttestationObject = new CborMap {
                     { "fmt", "testing" },
                     { "attStmt", new CborMap() },
-                    { "authData", Array.Empty<byte>() }
+                    { "authData", new AuthenticatorData(new byte[32], default, 0, null, null).ToByteArray() }
                 }.Encode(),
                 ClientDataJson = clientDataJson
             },
@@ -572,8 +572,8 @@ public class AuthenticatorResponse
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
-        Assert.Equal("AttestationResponse type must be 'public-key'", ex.Result.Message);
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback));
+        Assert.Equal("AttestationResponse type must be 'public-key'", ex.Message);
     }
 
     [Fact]

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -8,13 +8,24 @@ using Fido2NetLib.Cbor;
 using Fido2NetLib.Exceptions;
 using Fido2NetLib.Objects;
 using Fido2NetLib.Serialization;
+
 using NSec.Cryptography;
-using Test.Attestation;
 
 namespace Test;
 
-public class AuthenticatorResponse
+public class AuthenticatorResponseTests
 {
+    [Fact]
+    public void CanDeserialize()
+    {
+        var response = JsonSerializer.Deserialize<AuthenticatorResponse>("""{"type":"webauthn.get","challenge":"J4fjxBV-BNywGRJRm8JZ7znvdiZo9NINObNBpnKnJQEOtplTMF0ERuIrzrkeoO-dNMoeMZjhzqfar7eWRANvPeNFPrB5Q6zlS1ZFPf37F3suIwpXi9NCpFA_RlBSiygLmvcIOa57_QHubZQD3cv0UWtRTLslJjmgumphMc7EFN8","origin":"https://www.passwordless.dev"}""");
+
+        Assert.Equal("webauthn.get", response.Type);
+        Assert.Equal(Base64Url.Decode("J4fjxBV-BNywGRJRm8JZ7znvdiZo9NINObNBpnKnJQEOtplTMF0ERuIrzrkeoO-dNMoeMZjhzqfar7eWRANvPeNFPrB5Q6zlS1ZFPf37F3suIwpXi9NCpFA_RlBSiygLmvcIOa57_QHubZQD3cv0UWtRTLslJjmgumphMc7EFN8"), response.Challenge);
+        Assert.Equal("https://www.passwordless.dev", response.Origin);
+
+    }
+
     [Theory]
     [InlineData("https://www.passwordless.dev", "https://www.passwordless.dev")]
     [InlineData("https://www.passwordless.dev:443", "https://www.passwordless.dev:443")]
@@ -108,7 +119,7 @@ public class AuthenticatorResponse
             return Task.FromResult(true);
         };
 
-        IFido2 lib = new Fido2(new Fido2Configuration()
+        var lib = new Fido2(new Fido2Configuration()
         {
             ServerDomain = rp,
             ServerName = rp,
@@ -117,7 +128,6 @@ public class AuthenticatorResponse
 
         var result = await lib.MakeNewCredentialAsync(rawResponse, origChallenge, callback);
     }
-
 
     [Theory]
     [InlineData("https://www.passwordless.dev", "http://www.passwordless.dev")]
@@ -1272,7 +1282,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new (
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1343,7 +1353,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1413,7 +1423,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1483,7 +1493,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1554,7 +1564,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1625,7 +1635,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.create",
             challenge : challenge,
             origin    : rp
@@ -1696,7 +1706,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1768,7 +1778,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp
@@ -1839,7 +1849,7 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+        var authenticatorResponse = new AuthenticatorResponse(
             type      : "webauthn.get",
             challenge : challenge,
             origin    : rp

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -1272,12 +1272,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new (
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1344,12 +1343,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1415,12 +1413,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1486,12 +1483,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1558,12 +1554,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1630,12 +1625,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.create",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.create",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1702,12 +1696,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1775,12 +1768,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1847,12 +1839,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1919,12 +1910,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -1991,12 +1981,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
         
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -2063,12 +2052,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -2135,12 +2123,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -2207,12 +2194,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -2279,18 +2265,15 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
-        var options = new AssertionOptions
-        {
+        var options = new AssertionOptions {
             Challenge = challenge,
             RpId = rp,
             AllowCredentials = new[]
@@ -2351,13 +2334,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 
@@ -2423,13 +2404,11 @@ public class AuthenticatorResponse
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
 
-        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new()
-        {
-
-            Type = "webauthn.get",
-            Challenge = challenge,
-            Origin = rp,
-        };
+        Fido2NetLib.AuthenticatorResponse authenticatorResponse = new(
+            type      : "webauthn.get",
+            challenge : challenge,
+            origin    : rp
+        );
 
         byte[] clientDataJson = JsonSerializer.SerializeToUtf8Bytes(authenticatorResponse, FidoSerializerContext.Default.AuthenticatorResponse);
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="ReportGenerator" Version="5.1.14" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="ReportGenerator" Version="5.1.14" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
+++ b/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
+++ b/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR prevents the mutation of AuthenticatorData after parsing, and strongly types it throughout the library.

Ready for review.