### PR TITLE
Enable C# 11 and embed base64 encoded certificates as UTF-8 data

### DIFF
--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Fido2NetLib</RootNamespace>
     <IsTrimmable>true</IsTrimmable>
     <NoWarn>IDE0057</NoWarn>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
    
   <ItemGroup>

--- a/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
+++ b/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
@@ -18,19 +18,20 @@ namespace Fido2NetLib;
 
 public sealed class ConformanceMetadataRepository : IMetadataRepository
 {
-    private const string ROOT_CERT = "MIICaDCCAe6gAwIBAgIPBCqih0DiJLW7+UHXx/o1MAoGCCqGSM49BAMDMGcxCzAJ" +
-                                    "BgNVBAYTAlVTMRYwFAYDVQQKDA1GSURPIEFsbGlhbmNlMScwJQYDVQQLDB5GQUtF" +
-                                    "IE1ldGFkYXRhIDMgQkxPQiBST09UIEZBS0UxFzAVBgNVBAMMDkZBS0UgUm9vdCBG" +
-                                    "QUtFMB4XDTE3MDIwMTAwMDAwMFoXDTQ1MDEzMTIzNTk1OVowZzELMAkGA1UEBhMC" +
-                                    "VVMxFjAUBgNVBAoMDUZJRE8gQWxsaWFuY2UxJzAlBgNVBAsMHkZBS0UgTWV0YWRh" +
-                                    "dGEgMyBCTE9CIFJPT1QgRkFLRTEXMBUGA1UEAwwORkFLRSBSb290IEZBS0UwdjAQ" +
-                                    "BgcqhkjOPQIBBgUrgQQAIgNiAASKYiz3YltC6+lmxhPKwA1WFZlIqnX8yL5RybSL" +
-                                    "TKFAPEQeTD9O6mOz+tg8wcSdnVxHzwnXiQKJwhrav70rKc2ierQi/4QUrdsPes8T" +
-                                    "EirZOkCVJurpDFbXZOgs++pa4XmjYDBeMAsGA1UdDwQEAwIBBjAPBgNVHRMBAf8E" +
-                                    "BTADAQH/MB0GA1UdDgQWBBQGcfeCs0Y8D+lh6U5B2xSrR74eHTAfBgNVHSMEGDAW" +
-                                    "gBQGcfeCs0Y8D+lh6U5B2xSrR74eHTAKBggqhkjOPQQDAwNoADBlAjEA/xFsgri0" +
-                                    "xubSa3y3v5ormpPqCwfqn9s0MLBAtzCIgxQ/zkzPKctkiwoPtDzI51KnAjAmeMyg" +
-                                    "X2S5Ht8+e+EQnezLJBJXtnkRWY+Zt491wgt/AwSs5PHHMv5QgjELOuMxQBc=";
+    private static ReadOnlySpan<byte> ROOT_CERT => 
+        "MIICaDCCAe6gAwIBAgIPBCqih0DiJLW7+UHXx/o1MAoGCCqGSM49BAMDMGcxCzAJ"u8 +
+        "BgNVBAYTAlVTMRYwFAYDVQQKDA1GSURPIEFsbGlhbmNlMScwJQYDVQQLDB5GQUtF"u8 +
+        "IE1ldGFkYXRhIDMgQkxPQiBST09UIEZBS0UxFzAVBgNVBAMMDkZBS0UgUm9vdCBG"u8 +
+        "QUtFMB4XDTE3MDIwMTAwMDAwMFoXDTQ1MDEzMTIzNTk1OVowZzELMAkGA1UEBhMC"u8 +
+        "VVMxFjAUBgNVBAoMDUZJRE8gQWxsaWFuY2UxJzAlBgNVBAsMHkZBS0UgTWV0YWRh"u8 +
+        "dGEgMyBCTE9CIFJPT1QgRkFLRTEXMBUGA1UEAwwORkFLRSBSb290IEZBS0UwdjAQ"u8 +
+        "BgcqhkjOPQIBBgUrgQQAIgNiAASKYiz3YltC6+lmxhPKwA1WFZlIqnX8yL5RybSL"u8 +
+        "TKFAPEQeTD9O6mOz+tg8wcSdnVxHzwnXiQKJwhrav70rKc2ierQi/4QUrdsPes8T"u8 +
+        "EirZOkCVJurpDFbXZOgs++pa4XmjYDBeMAsGA1UdDwQEAwIBBjAPBgNVHRMBAf8E"u8 +
+        "BTADAQH/MB0GA1UdDgQWBBQGcfeCs0Y8D+lh6U5B2xSrR74eHTAfBgNVHSMEGDAW"u8 +
+        "gBQGcfeCs0Y8D+lh6U5B2xSrR74eHTAKBggqhkjOPQQDAwNoADBlAjEA/xFsgri0"u8 +
+        "xubSa3y3v5ormpPqCwfqn9s0MLBAtzCIgxQ/zkzPKctkiwoPtDzI51KnAjAmeMyg"u8 +
+        "X2S5Ht8+e+EQnezLJBJXtnkRWY+Zt491wgt/AwSs5PHHMv5QgjELOuMxQBc="u8;
 
     private readonly HttpClient _httpClient;
 

--- a/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
+++ b/Src/Fido2/Metadata/ConformanceMetadataRepository.cs
@@ -213,10 +213,8 @@ public sealed class ConformanceMetadataRepository : IMetadataRepository
             if (rootCert.Thumbprint.Equals(certChain.ChainElements[^1].Certificate.Thumbprint, StringComparison.Ordinal) &&
                 // and that the number of elements in the chain accounts for what was in x5c plus the root we added
                 certChain.ChainElements.Count == (x5cRawKeys.Length + 1) &&
-                // and that the root cert has exactly one status listed against it
-                certChain.ChainElements[^1].ChainElementStatus.Length == 1 &&
-                // and that that status is a status of exactly UntrustedRoot
-                certChain.ChainElements[^1].ChainElementStatus[0].Status == X509ChainStatusFlags.UntrustedRoot)
+                // and that the root cert has exactly one status with the value of UntrustedRoot
+                certChain.ChainElements[^1].ChainElementStatus is [ { Status: X509ChainStatusFlags.UntrustedRoot } ])
             {
                 // if we are good so far, that is a good sign
                 certChainIsValid = true;

--- a/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
+++ b/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
@@ -184,10 +184,8 @@ public sealed class Fido2MetadataServiceRepository : IMetadataRepository
             if (rootCert.Thumbprint == certChain.ChainElements[^1].Certificate.Thumbprint &&
                 // and that the number of elements in the chain accounts for what was in x5c plus the root we added
                 certChain.ChainElements.Count == (x5cRawKeys.Length + 1) &&
-                // and that the root cert has exactly one status listed against it
-                certChain.ChainElements[^1].ChainElementStatus.Length == 1 &&
-                // and that that status is a status of exactly UntrustedRoot
-                certChain.ChainElements[^1].ChainElementStatus[0].Status == X509ChainStatusFlags.UntrustedRoot)
+                // and that the root cert has exactly one status with the value of UntrustedRoot
+                certChain.ChainElements[^1].ChainElementStatus is [ { Status: X509ChainStatusFlags.UntrustedRoot } ])
             {
                 // if we are good so far, that is a good sign
                 certChainIsValid = true;

--- a/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
+++ b/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
@@ -16,26 +16,26 @@ namespace Fido2NetLib;
 
 public sealed class Fido2MetadataServiceRepository : IMetadataRepository
 {
-    private const string ROOT_CERT =
-    "MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G" +
-    "A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp" +
-    "Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4" +
-    "MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMzETMBEG" +
-    "A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI" +
-    "hvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWtiHL8" +
-    "RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsT" +
-    "gHeMCOFJ0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmm" +
-    "KPZpO/bLyCiR5Z2KYVc3rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zd" +
-    "QQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjlOCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZ" +
-    "XriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2xmmFghcCAwEAAaNCMEAw" +
-    "DgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI/wS3+o" +
-    "LkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZU" +
-    "RUm7lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMp" +
-    "jjM5RcOO5LlXbKr8EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK" +
-    "6fBdRoyV3XpYKBovHd7NADdBj+1EbddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQX" +
-    "mcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18YIvDQVETI53O9zJrlAGomecs" +
-    "Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH" +
-    "WD9f";
+    private ReadOnlySpan<byte> ROOT_CERT =>
+        "MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G"u8 +
+        "A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp"u8 +
+        "Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4"u8 +
+        "MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMzETMBEG"u8 +
+        "A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI"u8 +
+        "hvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWtiHL8"u8 +
+        "RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsT"u8 +
+        "gHeMCOFJ0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmm"u8 +
+        "KPZpO/bLyCiR5Z2KYVc3rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zd"u8 +
+        "QQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjlOCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZ"u8 +
+        "XriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2xmmFghcCAwEAAaNCMEAw"u8 +
+        "DgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI/wS3+o"u8 +
+        "LkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZU"u8 +
+        "RUm7lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMp"u8 +
+        "jjM5RcOO5LlXbKr8EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK"u8 +
+        "6fBdRoyV3XpYKBovHd7NADdBj+1EbddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQX"u8 +
+        "mcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18YIvDQVETI53O9zJrlAGomecs"u8 +
+        "Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH"u8 +
+        "WD9f"u8;
 
     private readonly string _blobUrl = "https://mds.fidoalliance.org/";
     private readonly IHttpClientFactory _httpClientFactory;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
     vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 6.0 SDK'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
-      version: '6.0.x'
+      version: '7.0.x'
       installationPath: $(Agent.ToolsDirectory)/dotnet-demo
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
@@ -50,10 +50,10 @@ jobs:
     vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 6.0 SDK'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
-      version: '6.0.x'
+      version: '7.0.x'
       installationPath: $(Agent.ToolsDirectory)/dotnet-demo
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
@@ -74,10 +74,10 @@ jobs:
     vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 6.0 SDK'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
-      version: '6.0.x'
+      version: '7.0.x'
       installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
@@ -128,10 +128,10 @@ jobs:
     vmImage: $(imageName)
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 6.0 SDK'
+    displayName: 'Use .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
-      version: '6.0.x'
+      version: '7.0.x'
       installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,6 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '7.0.x'
-      installationPath: $(Agent.ToolsDirectory)/dotnet-demo
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
@@ -74,11 +73,15 @@ jobs:
     vmImage: $(TargetWindowsVMImage)
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET 7.0 SDK'
+    displayName: 'Install .NET 6.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+  - task: UseDotNet@2
+    displayName: 'Install .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
       version: '7.0.x'
-      installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:
@@ -128,11 +131,15 @@ jobs:
     vmImage: $(imageName)
   steps:
   - task: UseDotNet@2
+    displayName: 'Use .NET 6.0 SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '6.0.x'
+  - task: UseDotNet@2
     displayName: 'Use .NET 7.0 SDK'
     inputs:
       packageType: 'sdk'
       version: '7.0.x'
-      installationPath: $(Agent.ToolsDirectory)/dotnet-unit-tests
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'
     inputs:


### PR DESCRIPTION
Is a bit faster to parse UTF-8 data directly than convert from UTF-16. 

NOTE, this uses the built-in support for static data initialization. Accessing ROOT_CERT is non-allocating and refers directly to the data.

This PR also simplifies a check using C# 11 list patterns.