### PR TITLE
Fix invalid type of `credProps` extension output

### DIFF
--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -53,10 +53,11 @@ public class AuthenticationExtensionsClientOutputs
 
     /// <summary>
     /// This client registration extension facilitates reporting certain credential properties known by the client to the requesting WebAuthn Relying Party upon creation of a public key credential source as a result of a registration ceremony.
+    /// https://www.w3.org/TR/webauthn/#sctn-authenticator-credential-properties-extension
     /// </summary>
     [JsonPropertyName("credProps")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? CredProps { get; set; }
+    public AuthenticationExtensionsCredentialPropertiesOutputs? CredProps { get; set; }
     
     /// <summary>
     /// This extension allows a Relying Party to evaluate outputs from a pseudo-random function (PRF) associated with a credential.

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsCredentialPropertiesOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsCredentialPropertiesOutputs.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+
+namespace Fido2NetLib.Objects;
+
+using System.Text.Json.Serialization;
+
+public sealed class AuthenticationExtensionsCredentialPropertiesOutputs
+{
+    /// <summary>
+    /// Whether the credential in question was created as a resident (discoverable) credential
+    /// </summary>
+    [JsonPropertyName("rk")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ResidentKey { get; set; }
+}


### PR DESCRIPTION
This PR resolves #415 

- Adds new type, `AuthenticationExtensionsCredentialPropertiesOutputs`
	- This properly conforms to the output type [defined in the spec](https://www.w3.org/TR/webauthn/#dictdef-credentialpropertiesoutput).
- Changes `AuthenticatorExtensionsClientOutputs.CredProps` type from `bool?` to `AuthenticationExtensionsCredentialPropertiesOutputs?`
- Adds link to spec entry on `credProps` extension in XML comment for `AuthenticatorExtensionsClientOutputs.CredProps` to conform with comment pattern in rest of file