### PR TITLE
CredentialId is no longer mapped

### DIFF
--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -188,6 +188,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         {
             Type = Raw.Type,
             Id = authData.AttestedCredentialData.CredentialID,
+            CredentialId = authData.AttestedCredentialData.CredentialID,
             PublicKey = authData.AttestedCredentialData.CredentialPublicKey.GetBytes(),
             SignCount = authData.SignCount,
             //Transports = result of response.getTransports();


### PR DESCRIPTION
Are we still using CredentialId? It is no longer mapped, and therefore null. Might have been a breaking change from @aseigler ?

https://github.com/passwordless-lib/fido2-net-lib/commit/7b92f4a019a9ed24793eedb8016408b44e9ee858#diff-1aab08f33f616a78e8c75fa260f05ac7726414bab4422b432c6c21c0d661dee4