### PR TITLE
Add smart-card and hybrid transports

### DIFF
--- a/Src/Fido2.Ctap2/Extensions/PubKeyCredParamExtensions.cs
+++ b/Src/Fido2.Ctap2/Extensions/PubKeyCredParamExtensions.cs
@@ -22,11 +22,13 @@ public static class AuthenticatorTransportExtensions
         #pragma warning disable format
         return value switch
         {
-            AuthenticatorTransport.Usb      => "usb",
-            AuthenticatorTransport.Nfc      => "nfc",
-            AuthenticatorTransport.Ble      => "ble",
-            AuthenticatorTransport.Internal => "internal",
-            _                               => value.ToString()
+            AuthenticatorTransport.Usb       => "usb",
+            AuthenticatorTransport.Nfc       => "nfc",
+            AuthenticatorTransport.Ble       => "ble",
+            AuthenticatorTransport.SmartCard => "smart-card",
+            AuthenticatorTransport.Hybrid    => "hybrid",
+            AuthenticatorTransport.Internal  => "internal",
+            _                                => value.ToString()
         };
         #pragma warning restore format
     }

--- a/Src/Fido2.Models/Objects/AuthenticatorTransport.cs
+++ b/Src/Fido2.Models/Objects/AuthenticatorTransport.cs
@@ -33,6 +33,19 @@ public enum AuthenticatorTransport
     Ble,
 
     /// <summary>
+    /// Indicates the respective authenticator can be contacted over over ISO/IEC 7816 smart card with contacts.
+    /// </summary>
+    [EnumMember(Value = "smart-card")]
+    SmartCard,
+
+    /// <summary>
+    /// Indicates the respective authenticator can be contacted using a combination of (often separate) data-transport
+    /// and proximity mechanisms. This supports, for example, authentication on a desktop computer using a smartphone.
+    /// </summary>
+    [EnumMember(Value = "hybrid")]
+    Hybrid,
+
+    /// <summary>
     /// Indicates the respective authenticator is contacted using a client device-specific transport, i.e., it is a platform authenticator. 
     /// These authenticators are not removable from the client device.
     /// </summary>


### PR DESCRIPTION
Windows now natively supports hybrid (smartphone QR) transport.
https://w3c.github.io/webauthn/#enum-transport

Edit: fixes https://github.com/passwordless-lib/fido2-net-lib/issues/325