### PR TITLE
Align MSBuild properties across all projects

### DIFF
--- a/BlazorWasmDemo/Client/BlazorWasmDemo.Client.csproj
+++ b/BlazorWasmDemo/Client/BlazorWasmDemo.Client.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorWasmDemo/Client/BlazorWasmDemo.Client.csproj
+++ b/BlazorWasmDemo/Client/BlazorWasmDemo.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/BlazorWasmDemo/Server/BlazorWasmDemo.Server.csproj
+++ b/BlazorWasmDemo/Server/BlazorWasmDemo.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UserSecretsId>d4e312c9-f55a-43e0-b3ea-699aa6421a5c</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/BlazorWasmDemo/Server/BlazorWasmDemo.Server.csproj
+++ b/BlazorWasmDemo/Server/BlazorWasmDemo.Server.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>d4e312c9-f55a-43e0-b3ea-699aa6421a5c</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
-    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +19,5 @@
     <ProjectReference Include="..\..\Src\Fido2\Fido2.csproj" />
     <ProjectReference Include="..\Client\BlazorWasmDemo.Client.csproj" />
   </ItemGroup>
-
 
 </Project>

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,21 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
+    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
     <RootNamespace>Fido2Demo</RootNamespace>
+    <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Src\Fido2.AspNet\Fido2.AspNet.csproj" />
     <ProjectReference Include="..\Src\Fido2.Development\Fido2.Development.csproj" />
     <ProjectReference Include="..\Src\Fido2.Models\Fido2.Models.csproj" />
     <ProjectReference Include="..\Src\Fido2\Fido2.csproj" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\bulma\" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Update="Pages\custom.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
@@ -30,4 +35,5 @@
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Fido2Demo</RootNamespace>
     <UserSecretsId>39589262-6aa1-4bde-aaa9-403a7542cf63</UserSecretsId>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,7 @@
   <!-- Package Metadata -->
   <PropertyGroup>
     <VersionPrefix>4.0.0-beta3</VersionPrefix>
-    <VersionSuffix>
-    </VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <Description>FIDO2 .NET library (WebAuthn)</Description>
     <RepositoryUrl>https://github.com/passwordless-lib/fido2-net-lib</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -13,15 +12,19 @@
     <PackageProjectUrl>https://github.com/passwordless-lib/fido2-net-lib</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+  
   <!-- Global Variables -->
   <PropertyGroup>
     <SupportedTargetFrameworks>net6.0</SupportedTargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  
   <!-- Language + Compiler Settings-->
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
+  
   <!--MISC-->
   <PropertyGroup>
     <!-- Avoid annoying build warnings when packing using the solution file -->

--- a/Src/Fido2.AspNet/Fido2.AspNet.csproj
+++ b/Src/Fido2.AspNet/Fido2.AspNet.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Fido2NetLib</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Fido2\Fido2.csproj" />
     <ProjectReference Include="..\Fido2.Models\Fido2.Models.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 </Project>

--- a/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
+++ b/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <RootNamespace>Fido2NetLib</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <IsTrimmable>true</IsTrimmable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
@@ -37,10 +37,6 @@
     <Content Update="wwwroot\js\WebAuthn.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
+++ b/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Fido2NetLib</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>

--- a/Src/Fido2.Ctap2/Fido2.Ctap2.csproj
+++ b/Src/Fido2.Ctap2/Fido2.Ctap2.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Fido2NetLib</RootNamespace>
     <Nullable>enable</Nullable>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
@@ -10,4 +10,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Fido2\Fido2.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Src/Fido2.Development/Fido2.Development.csproj
+++ b/Src/Fido2.Development/Fido2.Development.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Fido2NetLib</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Src/Fido2.Models/Fido2.Models.csproj
+++ b/Src/Fido2.Models/Fido2.Models.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Fido2NetLib</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsTrimmable>true</IsTrimmable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <Compile Remove="IMetadataService.cs" />
-  </ItemGroup>
+
 </Project>

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -1,22 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <RootNamespace>Fido2NetLib</RootNamespace>
+    <Nullable>enable</Nullable>
     <IsTrimmable>true</IsTrimmable>
-    <NoWarn>IDE0057</NoWarn>
-    <LangVersion>11</LangVersion>
+    <NoWarn>$(NoWarn);IDE0057</NoWarn>
   </PropertyGroup>
-   
-  <ItemGroup>
-    <None Remove="Fido2MetadataServiceRepository.cs" />
-    <None Remove="FileSystemMetadataRepository.cs" />
-    <None Remove="IMetadataRepository.cs" />
-    <None Remove="Metadata\ConformanceMetadataRepository.cs" />
-    <None Remove="StaticMetadataRepository.cs" />
-  </ItemGroup>
 
-  <!-- References -->
   <ItemGroup>
     <ProjectReference Include="..\Fido2.Models\Fido2.Models.csproj" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
@@ -32,4 +23,5 @@
     -->
     <Content Include="build/fido2.targets" PackagePath="build/" />
   </ItemGroup>
+
 </Project>

--- a/Src/Fido2/Fido2.csproj
+++ b/Src/Fido2/Fido2.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Fido2NetLib</RootNamespace>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
     <IsTrimmable>true</IsTrimmable>
     <NoWarn>$(NoWarn);IDE0057</NoWarn>
   </PropertyGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LangVersion>preview</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>CA1822,IDE0007,IDE0037,IDE0039,IDE0057,CA1825</NoWarn>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <NoWarn>CA1822,IDE0007,IDE0037,IDE0039,IDE0057,CA1825</NoWarn>
+    <NoWarn>$(NoWarm);CA1822;IDE0007;IDE0037;IDE0039;IDE0057;CA1825</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
+++ b/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
+    <TargetFrameworks>$(SupportedTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
+++ b/Tests/Fido2.Ctap2.Tests/Fido2.Ctap2.Tests.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(SupportedTargetFrameworks)</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Set `TargetFrameworks` to `$(SupportedTargetFrameworks)`
- Align `LanguageVersion` to 11
- Set `ImplicitUsings` to `enable` in root `Directory.Build.props`
- Miscellaneous cleanup 