### PR TITLE
Update to latest version of FIDO Metadata Service

### DIFF
--- a/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
+++ b/Src/Fido2/Metadata/Fido2MetadataServiceRepository.cs
@@ -37,7 +37,7 @@ public sealed class Fido2MetadataServiceRepository : IMetadataRepository
         "Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH"u8 +
         "WD9f"u8;
 
-    private readonly string _blobUrl = "https://mds.fidoalliance.org/";
+    private readonly string _blobUrl = "https://mds3.fidoalliance.org/";
     private readonly IHttpClientFactory _httpClientFactory;
 
     public Fido2MetadataServiceRepository(IHttpClientFactory httpClientFactory)


### PR DESCRIPTION
Update to the latest MDS3 BLOB url. The format of the BLOB didn't change and the root certificate to validate it neither.