### PR TITLE
[Draft] Add credProtect extension to Fido2.Models

### DIFF
--- a/Src/Fido2.Models/Converters/FidoEnumConverter.cs
+++ b/Src/Fido2.Models/Converters/FidoEnumConverter.cs
@@ -10,15 +10,26 @@ public sealed class FidoEnumConverter<[DynamicallyAccessedMembers(DynamicallyAcc
 {
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        string text = reader.GetString();
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                string text = reader.GetString();
+                if (EnumNameMapper<T>.TryGetValue(text, out T value))
+                    return value;
+                else
+                    throw new JsonException($"Invalid enum value = \"{text}\"");
 
-        if (EnumNameMapper<T>.TryGetValue(reader.GetString(), out T value))
-        {
-            return value;
-        }
-        else
-        {
-            throw new JsonException($"Invalid enum value = {text}");
+            case JsonTokenType.Number:
+                if (!reader.TryGetInt32(out var number))
+                    throw new JsonException($"Invalid enum value = {reader.GetString()}");
+                var casted = (T)(object)number; // ints can always be casted to enum, even when the value is not defined
+                if (Enum.IsDefined(casted))
+                    return casted;
+                else
+                    throw new JsonException($"Invalid enum value = {number}");
+
+            default:
+                throw new JsonException($"Invalid enum value ({reader.TokenType})");
         }
     }
 

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientInputs.cs
@@ -69,5 +69,27 @@ public sealed class AuthenticationExtensionsClientInputs
     [JsonPropertyName("prf")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public AuthenticationExtensionsPRFInputs? PRF { get; set; }
+
+    /// <summary>
+    /// This registration extension allows relying parties to specify a credential protection policy when creating a credential.
+    /// Additionally, authenticators MAY choose to establish a default credential protection policy greater than <c>UserVerificationOptional</c> (the lowest level)
+    /// and unilaterally enforce such policy. Authenticators not supporting some form of user verification MUST NOT support this extension.
+    /// Authenticators supporting some form of user verification MUST process this extension and persist the credProtect value with the credential,
+    /// even if the authenticator is not protected by some form of user verification at the time.
+    /// https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#sctn-credProtect-extension
+    /// </summary>
+    [JsonPropertyName("credentialProtectionPolicy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public CredentialProtectionPolicy? CredentialProtectionPolicy { get; set; }
+
+    /// <summary>
+    ///  This controls whether it is better to fail to create a credential rather than ignore the protection policy.
+    ///  When true, and <c>CredentialProtectionPolicy</c>'s value is
+    ///  either <c>UserVerificationOptionalWithCredentialIdList</c> or <c>UserVerificationRequired</c>, the platform
+    ///  SHOULD NOT create the credential in a way that does not implement the requested protection policy.
+    /// </summary>
+    [JsonPropertyName("enforceCredentialProtectionPolicy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? EnforceCredentialProtectionPolicy { get; set; }
 }
 

--- a/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
+++ b/Src/Fido2.Models/Objects/AuthenticationExtensionsClientOutputs.cs
@@ -65,4 +65,13 @@ public class AuthenticationExtensionsClientOutputs
     [JsonPropertyName("prf")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public AuthenticationExtensionsPRFOutputs? PRF { get; set; }
+
+
+    /// <summary>
+    /// The <c>CredentialProtectionPolicy</c> stored alongside the created credential
+    /// https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#sctn-credProtect-extension
+    /// </summary>
+    [JsonPropertyName("credProtect")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public CredentialProtectionPolicy? CredProtect { get; set; }
 }

--- a/Src/Fido2.Models/Objects/CredentialProtectionPolicy.cs
+++ b/Src/Fido2.Models/Objects/CredentialProtectionPolicy.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Fido2NetLib.Objects;
+
+/// <summary>
+/// CredentialProtectionPolicy
+/// https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#sctn-credProtect-extension
+/// </summary>
+[JsonConverter(typeof(FidoEnumConverter<CredentialProtectionPolicy>))]
+public enum CredentialProtectionPolicy
+{
+    /// <summary>
+    /// This reflects "FIDO_2_0" semantics. In this configuration, performing some form of user verification is OPTIONAL with or without credentialID list.
+    /// This is the default state of the credential if the extension is not specified
+    /// </summary>
+    [EnumMember(Value = "userVerificationOptional")]
+    UserVerificationOptional = 0x01,
+
+    /// <summary>
+    /// In this configuration, credential is discovered only when its credentialID is provided by the platform or when some form of user verification is performed.
+    /// </summary>
+    [EnumMember(Value = "userVerificationOptionalWithCredentialIDList")]
+    UserVerificationOptionalWithCredentialIdList = 0x02,
+
+    /// <summary>
+    /// TThis reflects that discovery and usage of the credential MUST be preceded by some form of user verification.
+    /// </summary>
+    [EnumMember(Value = "userVerificationRequired")]
+    UserVerificationRequired = 0x03
+}

--- a/Test/Converters/FidoEnumConverterTests.cs
+++ b/Test/Converters/FidoEnumConverterTests.cs
@@ -30,6 +30,14 @@ public class FidoEnumConverterTests
     }
 
     [Fact]
+    public void CorrectlyDeserializesNumericEnumValue()
+    {
+        Assert.Equal(CredentialProtectionPolicy.UserVerificationRequired, JsonSerializer.Deserialize<CredentialProtectionPolicy>($"{CredentialProtectionPolicy.UserVerificationRequired:d}"));
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CredentialProtectionPolicy>($"99"));
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CredentialProtectionPolicy>($"99.7"));
+    }
+
+    [Fact]
     public void DeserializationIsCaseInsensitive()
     {
         Assert.Equal("\"A\"", JsonSerializer.Serialize(ABC.A));


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#credprotect
https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#sctn-credProtect-extension

The input part should be okay, but does the extension output need parsing from JSON? Or should it be extracted from the `authenticator data` CBOR?
