### PR TITLE
Map authenticator transports on server side

### DIFF
--- a/Demo/wwwroot/js/custom.register.js
+++ b/Demo/wwwroot/js/custom.register.js
@@ -125,8 +125,7 @@ async function registerNewCredential(newCredential) {
         extensions: newCredential.getClientExtensionResults(),
         response: {
             AttestationObject: coerceToBase64Url(attestationObject),
-            clientDataJSON: coerceToBase64Url(clientDataJSON),
-            transports: newCredential.response.getTransports(),
+            clientDataJSON: coerceToBase64Url(clientDataJSON)
         },
     };
 

--- a/Demo/wwwroot/js/custom.register.js
+++ b/Demo/wwwroot/js/custom.register.js
@@ -125,7 +125,8 @@ async function registerNewCredential(newCredential) {
         extensions: newCredential.getClientExtensionResults(),
         response: {
             AttestationObject: coerceToBase64Url(attestationObject),
-            clientDataJSON: coerceToBase64Url(clientDataJSON)
+            clientDataJSON: coerceToBase64Url(clientDataJSON),
+            transports: newCredential.response.getTransports()
         },
     };
 

--- a/Demo/wwwroot/js/mfa.register.js
+++ b/Demo/wwwroot/js/mfa.register.js
@@ -130,7 +130,8 @@ async function registerNewCredential(newCredential) {
         extensions: newCredential.getClientExtensionResults(),
         response: {
             AttestationObject: coerceToBase64Url(attestationObject),
-            clientDataJSON: coerceToBase64Url(clientDataJSON)
+            clientDataJSON: coerceToBase64Url(clientDataJSON),
+            transports: newCredential.response.getTransports()
         }
     };
 

--- a/Demo/wwwroot/js/passwordless.register.js
+++ b/Demo/wwwroot/js/passwordless.register.js
@@ -127,7 +127,8 @@ async function registerNewCredential(newCredential) {
         extensions: newCredential.getClientExtensionResults(),
         response: {
             AttestationObject: coerceToBase64Url(attestationObject),
-            clientDataJSON: coerceToBase64Url(clientDataJSON)
+            clientDataJSON: coerceToBase64Url(clientDataJSON),
+            transports: newCredential.response.getTransports()
         }
     };
 

--- a/Demo/wwwroot/js/usernameless.register.js
+++ b/Demo/wwwroot/js/usernameless.register.js
@@ -128,7 +128,8 @@ async function registerNewCredential(newCredential) {
         extensions: newCredential.getClientExtensionResults(),
         response: {
             attestationObject: coerceToBase64Url(attestationObject),
-            clientDataJSON: coerceToBase64Url(clientDataJSON)
+            clientDataJSON: coerceToBase64Url(clientDataJSON),
+            transports: newCredential.response.getTransports()
         }
     };
 

--- a/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
+++ b/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
@@ -32,7 +32,8 @@ export async function createCreds(options: PublicKeyCredentialCreationOptions) {
         extensions: newCreds.getClientExtensionResults(),
         response: {
             attestationObject: toBase64Url(response.attestationObject),
-            clientDataJSON: toBase64Url(response.clientDataJSON)
+            clientDataJSON: toBase64Url(response.clientDataJSON),
+            transports: response.getTransports ? response.getTransports() : []
         }
     };
     return retval;

--- a/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
+++ b/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
@@ -32,8 +32,7 @@ export async function createCreds(options: PublicKeyCredentialCreationOptions) {
         extensions: newCreds.getClientExtensionResults(),
         response: {
             attestationObject: toBase64Url(response.attestationObject),
-            clientDataJSON: toBase64Url(response.clientDataJSON),
-            transports: response.getTransports ? response.getTransports() : [],
+            clientDataJSON: toBase64Url(response.clientDataJSON)
         }
     };
     return retval;

--- a/Src/Fido2.Models/AuthenticatorAttestationRawResponse.cs
+++ b/Src/Fido2.Models/AuthenticatorAttestationRawResponse.cs
@@ -32,5 +32,8 @@ public sealed class AuthenticatorAttestationRawResponse
         [JsonConverter(typeof(Base64UrlConverter))]
         [JsonPropertyName("clientDataJSON")]
         public byte[] ClientDataJson { get; set; }
+
+        [JsonPropertyName("transports")]
+        public AuthenticatorTransport[] Transports { get; set; }
     }
 }

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -190,7 +190,7 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
             Id = authData.AttestedCredentialData.CredentialId,
             PublicKey = authData.AttestedCredentialData.CredentialPublicKey.GetBytes(),
             SignCount = authData.SignCount,
-            // Transports = result of response.getTransports();
+            Transports = Raw.Response.Transports,
             IsBackupEligible = authData.IsBackupEligible,
             IsBackedUp = authData.IsBackedUp,
             AttestationObject = Raw.Response.AttestationObject,

--- a/Test/Attestation/AndroidKey.cs
+++ b/Test/Attestation/AndroidKey.cs
@@ -76,6 +76,7 @@ public class AndroidKey : Fido2Tests.Attestation
         Assert.Equal("Test User", res.Result.User.DisplayName);
         Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
         Assert.Equal("testuser", res.Result.User.Name);
+        Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
     }
 
     [Fact]

--- a/Test/Attestation/AndroidSafetyNet.cs
+++ b/Test/Attestation/AndroidSafetyNet.cs
@@ -113,6 +113,7 @@ public class AndroidSafetyNet : Fido2Tests.Attestation
         Assert.Equal("Test User", res.Result.User.DisplayName);
         Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
         Assert.Equal("testuser", res.Result.User.Name);
+        Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
     }
 
     [Fact]

--- a/Test/Attestation/FidoU2f.cs
+++ b/Test/Attestation/FidoU2f.cs
@@ -68,6 +68,7 @@ public class FidoU2f : Fido2Tests.Attestation
         Assert.Equal("Test User", res.Result.User.DisplayName);
         Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
         Assert.Equal("testuser", res.Result.User.Name);
+        Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
     }
 
     [Fact]

--- a/Test/Attestation/Packed.cs
+++ b/Test/Attestation/Packed.cs
@@ -48,6 +48,7 @@ public class Packed : Fido2Tests.Attestation
             Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
             Assert.Equal("testuser", res.Result.User.Name);
             _attestationObject = new CborMap { { "fmt", "packed" } };
+            Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
         }
     }
 

--- a/Test/Attestation/Tpm.cs
+++ b/Test/Attestation/Tpm.cs
@@ -305,6 +305,7 @@ public class Tpm : Fido2Tests.Attestation
             Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
             Assert.Equal("testuser", res.Result.User.Name);
             _attestationObject = new CborMap { { "fmt", "tpm" } };
+            Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
         }
     }
 
@@ -422,6 +423,7 @@ public class Tpm : Fido2Tests.Attestation
         Assert.Equal("Test User", res.Result.User.DisplayName);
         Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
         Assert.Equal("testuser", res.Result.User.Name);
+        Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
     }
 
     [Fact]
@@ -5060,6 +5062,7 @@ public class Tpm : Fido2Tests.Attestation
         Assert.Equal("Test User", res.Result.User.DisplayName);
         Assert.Equal("testuser"u8.ToArray(), res.Result.User.Id);
         Assert.Equal("testuser", res.Result.User.Name);
+        Assert.Equal(new[] { AuthenticatorTransport.Internal }, res.Result.Transports);
     }
 
     [Fact]

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -163,6 +163,7 @@ public class Fido2Tests
                 {
                     AttestationObject = _attestationObject.Encode(),
                     ClientDataJson = _clientDataJson,
+                    Transports = new[] { AuthenticatorTransport.Internal }
                 },
                 Extensions = new AuthenticationExtensionsClientOutputs()
                 {


### PR DESCRIPTION
Map the authenticator transports on server side. The demo app already stores the value:

https://github.com/passwordless-lib/fido2-net-lib/blob/ebfd75d00a945a80578b27a256223122cc2aefe9/Demo/Controller.cs#L130