### PR TITLE
Update timeout data type to ulong

### DIFF
--- a/Src/Fido2.Models/AssertionOptions.cs
+++ b/Src/Fido2.Models/AssertionOptions.cs
@@ -24,7 +24,7 @@ public class AssertionOptions : Fido2ResponseBase
     /// This member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete. This is treated as a hint, and MAY be overridden by the client.
     /// </summary>
     [JsonPropertyName("timeout")]
-    public uint Timeout { get; set; }
+    public ulong Timeout { get; set; }
 
     /// <summary>
     /// This OPTIONAL member specifies the relying party identifier claimed by the caller.If omitted, its value will be the CredentialsContainer object’s relevant settings object's origin's effective domain

--- a/Src/Fido2.Models/CredentialCreateOptions.cs
+++ b/Src/Fido2.Models/CredentialCreateOptions.cs
@@ -43,7 +43,7 @@ public sealed class CredentialCreateOptions : Fido2ResponseBase
     /// This member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete. This is treated as a hint, and MAY be overridden by the platform.
     /// </summary>
     [JsonPropertyName("timeout")]
-    public long Timeout { get; set; }
+    public ulong Timeout { get; set; }
 
     /// <summary>
     /// This member is intended for use by Relying Parties that wish to express their preference for attestation conveyance.The default is none.


### PR DESCRIPTION
Fixes #198.

From the [spec](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-timeout), for both `PublicKeyCredentialCreationOptions` and `PublicKeyCredentialRequestOptions`:
```
timeout, of type [unsigned long](https://heycam.github.io/webidl/#idl-unsigned-long)
```

So I changed the data type to `ulong`.