### PR TITLE
Remove binary serialization

### DIFF
--- a/Src/Fido2.Models/Exceptions/Fido2MetadataException.cs
+++ b/Src/Fido2.Models/Exceptions/Fido2MetadataException.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Runtime.Serialization;
+﻿namespace Fido2NetLib;
 
-namespace Fido2NetLib;
-
-[Serializable]
 public class Fido2MetadataException : Exception
 {
     public Fido2MetadataException()
@@ -15,10 +11,6 @@ public class Fido2MetadataException : Exception
     }
 
     public Fido2MetadataException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-
-    protected Fido2MetadataException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 }

--- a/Src/Fido2.Models/Exceptions/Fido2VerificationException.cs
+++ b/Src/Fido2.Models/Exceptions/Fido2VerificationException.cs
@@ -5,7 +5,6 @@ using Fido2NetLib.Exceptions;
 
 namespace Fido2NetLib;
 
-[Serializable]
 public class Fido2VerificationException : Exception
 {
     public Fido2VerificationException()
@@ -27,10 +26,6 @@ public class Fido2VerificationException : Exception
     }
 
     public Fido2VerificationException(string message, Exception innerException) : base(message, innerException)
-    {
-    }
-
-    protected Fido2VerificationException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/Src/Fido2.Models/UndesiredMetadataStatusFido2VerificationException.cs
+++ b/Src/Fido2.Models/UndesiredMetadataStatusFido2VerificationException.cs
@@ -1,20 +1,14 @@
-﻿using System;
-using System.Runtime.Serialization;
-
-namespace Fido2NetLib;
+﻿namespace Fido2NetLib;
 
 /// <summary>
 /// Exception thrown when a new attestation comes from an authenticator with a current reported security issue.
 /// </summary>
-[Serializable]
 public class UndesiredMetadataStatusFido2VerificationException : Fido2VerificationException
 {
     public UndesiredMetadataStatusFido2VerificationException(StatusReport statusReport) : base($"Authenticator found with undesirable status. Was {statusReport.Status}")
     {
         StatusReport = statusReport;
     }
-
-    protected UndesiredMetadataStatusFido2VerificationException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
     /// <summary>
     /// Status report from the authenticator that caused the attestation to be rejected.


### PR DESCRIPTION
Binary serialization support is no longer recommended as .NET5.0 and is obsoleted entirely in .NET 8.0 in preparation for its removal in .NET 9.0.

https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md

This PR removes binary serialization support on Exceptions (and eliminates the warnings when targeting .NET8.0) -- and helps ensure no-one relies on these when support is removed in .NET 9.0.