### PR TITLE
Change `List<byte[]> storedDevicePublicKeys` to `IReadOnlyList<byte[]>`

### DIFF
--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -57,7 +57,7 @@ public sealed class AuthenticatorAssertionResponse : AuthenticatorResponse
         AssertionOptions options,
         Fido2Configuration config,
         byte[] storedPublicKey,
-        List<byte[]> storedDevicePublicKeys,
+        IReadOnlyList<byte[]> storedDevicePublicKeys,
         uint storedSignatureCounter,
         IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredId,
         IMetadataService? metadataService,
@@ -235,7 +235,7 @@ public sealed class AuthenticatorAssertionResponse : AuthenticatorResponse
     /// <param name="hash"></param>
     /// </summary>
     private static async ValueTask<byte[]?> DevicePublicKeyAuthenticationAsync(
-        List<byte[]> storedDevicePublicKeys,
+        IReadOnlyList<byte[]> storedDevicePublicKeys,
         AuthenticationExtensionsClientOutputs clientExtensionResults,
         AuthenticatorData authData,
         byte[] hash)
@@ -320,7 +320,7 @@ public sealed class AuthenticatorAssertionResponse : AuthenticatorResponse
                 List<DevicePublicKeyAuthenticatorOutput> matchedDpkKeys = new();
 
                 // For each dpkRecord in credentialRecord.devicePubKeys
-                storedDevicePublicKeys.ForEach(storedDevicePublicKey =>
+                foreach (var storedDevicePublicKey in storedDevicePublicKeys)
                 {
                     var dpkRecord = DevicePublicKeyAuthenticatorOutput.Parse(storedDevicePublicKey);
 
@@ -330,7 +330,7 @@ public sealed class AuthenticatorAssertionResponse : AuthenticatorResponse
                         // Append dpkRecord to matchedDpkKeys.
                         matchedDpkKeys.Add(dpkRecord);
                     }
-                });
+                }
 
                 // If matchedDpkKeys is empty
                 if (matchedDpkKeys.Count == 0)

--- a/Src/Fido2/Fido2.cs
+++ b/Src/Fido2/Fido2.cs
@@ -108,7 +108,7 @@ public class Fido2 : IFido2
         AuthenticatorAssertionRawResponse assertionResponse,
         AssertionOptions originalOptions,
         byte[] storedPublicKey,
-        List<byte[]> storedDevicePublicKeys,
+        IReadOnlyList<byte[]> storedDevicePublicKeys,
         uint storedSignatureCounter,
         IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredentialIdCallback,
         CancellationToken cancellationToken = default)

--- a/Src/Fido2/IFido2.cs
+++ b/Src/Fido2/IFido2.cs
@@ -17,7 +17,7 @@ public interface IFido2
         AuthenticatorAssertionRawResponse assertionResponse,
         AssertionOptions originalOptions,
         byte[] storedPublicKey,
-        List<byte[]> storedDevicePublicKeys,
+        IReadOnlyList<byte[]> storedDevicePublicKeys,
         uint storedSignatureCounter,
         IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredentialIdCallback,
         CancellationToken cancellationToken = default);


### PR DESCRIPTION
Following #447, this PR changes `List<byte[]> storedDevicePublicKeys` to `IReadOnlyList<byte[]>`.

There is no impact on the demo website as the stored credential contains a `List<byte[]>` for the device's public keys, which is compatible with `IReadOnlyList<byte[]>`.

https://github.com/passwordless-lib/fido2-net-lib/blob/528475729fe23ac68602bbd6d4e053de4b333fe5/Src/Fido2.Development/StoredCredential.cs#L51