### PR TITLE
Rename `extensions` to `clientExtensionResults`

### DIFF
--- a/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
+++ b/Src/Fido2.BlazorWebAssembly/wwwroot/js/WebAuthn.ts
@@ -29,7 +29,7 @@ export async function createCreds(options: PublicKeyCredentialCreationOptions) {
         id: base64StringToUrl(newCreds.id),
         rawId: toBase64Url(newCreds.rawId),
         type: newCreds.type,
-        extensions: newCreds.getClientExtensionResults(),
+        clientExtensionResults: newCreds.getClientExtensionResults(),
         response: {
             attestationObject: toBase64Url(response.attestationObject),
             clientDataJSON: toBase64Url(response.clientDataJSON),
@@ -55,6 +55,7 @@ export async function verify(options: PublicKeyCredentialRequestOptions) {
         id: creds.id,
         rawId: toBase64Url(creds.rawId),
         type: creds.type,
+        clientExtensionResults: creds.getClientExtensionResults(),
         response: {
             authenticatorData: toBase64Url(response.authenticatorData),
             clientDataJSON: toBase64Url(response.clientDataJSON),

--- a/Src/Fido2.Models/AuthenticatorAttestationRawResponse.cs
+++ b/Src/Fido2.Models/AuthenticatorAttestationRawResponse.cs
@@ -21,7 +21,15 @@ public sealed class AuthenticatorAttestationRawResponse
     public AttestationResponse Response { get; set; }
 
     [JsonPropertyName("extensions")]
-    public AuthenticationExtensionsClientOutputs Extensions { get; set; }
+    [Obsolete("Use ClientExtensionResults instead")]
+    public AuthenticationExtensionsClientOutputs Extensions
+    {
+        get => ClientExtensionResults;
+        set => ClientExtensionResults = value;
+    }
+
+    [JsonPropertyName("clientExtensionResults")]
+    public AuthenticationExtensionsClientOutputs ClientExtensionResults { get; set; }
 
     public sealed class AttestationResponse
     {

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -123,9 +123,9 @@ public sealed class AuthenticatorAttestationResponse : AuthenticatorResponse
         // TODO?: Implement sort of like this: ClientExtensions.Keys.Any(x => options.extensions.contains(x);
         byte[]? devicePublicKeyResult = null;
 
-        if (Raw.Extensions?.DevicePubKey is not null)
+        if (Raw.ClientExtensionResults?.DevicePubKey is not null)
         {
-            devicePublicKeyResult = await DevicePublicKeyRegistrationAsync(config, metadataService, Raw.Extensions, AttestationObject.AuthData, clientDataHash, cancellationToken).ConfigureAwait(false);
+            devicePublicKeyResult = await DevicePublicKeyRegistrationAsync(config, metadataService, Raw.ClientExtensionResults, AttestationObject.AuthData, clientDataHash, cancellationToken).ConfigureAwait(false);
         }
 
         // 19. Determine the attestation statement format by performing a USASCII case-sensitive match on fmt

--- a/Test/AuthenticatorResponse.cs
+++ b/Test/AuthenticatorResponse.cs
@@ -253,7 +253,7 @@ public class AuthenticatorResponseTests
                 AttestationObject = new CborMap().Encode(),
                 ClientDataJson = clientDataJson
             },
-            Extensions = new AuthenticationExtensionsClientOutputs
+            ClientExtensionResults = new AuthenticationExtensionsClientOutputs
             {
                 AppID = true,
                 Extensions = new string[] { "foo", "bar" },
@@ -281,13 +281,13 @@ public class AuthenticatorResponseTests
         Assert.Equal(new byte[] { 0xf1, 0xd0 }, rawResponse.RawId);
         Assert.Equal(new byte[] { 0xa0 }, rawResponse.Response.AttestationObject);
         Assert.Equal(clientDataJson, rawResponse.Response.ClientDataJson);
-        Assert.True(rawResponse.Extensions.AppID);
-        Assert.Equal(new string[] { "foo", "bar" }, rawResponse.Extensions.Extensions);
-        Assert.Equal("test", rawResponse.Extensions.Example);
-        Assert.Equal((ulong)4, rawResponse.Extensions.UserVerificationMethod[0][0]);
-        Assert.True(rawResponse.Extensions.PRF.Enabled);
-        Assert.Equal(rawResponse.Extensions.PRF.Results.First, new byte[] { 0xf1, 0xd0 });
-        Assert.Equal(new byte[] { 0xf1, 0xd0 }, rawResponse.Extensions.PRF.Results.Second);
+        Assert.True(rawResponse.ClientExtensionResults.AppID);
+        Assert.Equal(new string[] { "foo", "bar" }, rawResponse.ClientExtensionResults.Extensions);
+        Assert.Equal("test", rawResponse.ClientExtensionResults.Example);
+        Assert.Equal((ulong)4, rawResponse.ClientExtensionResults.UserVerificationMethod[0][0]);
+        Assert.True(rawResponse.ClientExtensionResults.PRF.Enabled);
+        Assert.Equal(rawResponse.ClientExtensionResults.PRF.Results.First, new byte[] { 0xf1, 0xd0 });
+        Assert.Equal(new byte[] { 0xf1, 0xd0 }, rawResponse.ClientExtensionResults.PRF.Results.Second);
     }
 
     [Fact]

--- a/Test/Fido2Tests.cs
+++ b/Test/Fido2Tests.cs
@@ -165,7 +165,7 @@ public class Fido2Tests
                     ClientDataJson = _clientDataJson,
                     Transports = new[] { AuthenticatorTransport.Internal }
                 },
-                Extensions = new AuthenticationExtensionsClientOutputs()
+                ClientExtensionResults = new AuthenticationExtensionsClientOutputs()
                 {
                     AppID = true,
                     Extensions = new string[] { "foo", "bar" },


### PR DESCRIPTION
Following #474, same change has been done on `AuthenticatorAttestationRawResponse`. Additionally, the new `clientExtensionResults` is now used in `Fido2.BlazorWebAssembly` project.

@abergs, do you want me to update the demo project as well to use the new `ClientExtensionResults` prop?