### PR TITLE
Added authenticatorDisplayName to ClientPropertiesOutput

### DIFF
--- a/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
+++ b/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
@@ -13,4 +13,11 @@ public class CredentialPropertiesOutput
     /// </summary>
     [JsonPropertyName("rk")]
     public bool Rk { get; set; }
+
+
+    /// <summary>
+    /// This OPTIONAL property is a human-palatable description of the credential’s managing authenticator, chosen by the user.
+    /// </summary>
+    [JsonPropertyName("authenticatorDisplayName")]
+    public string? AuthenticatorDisplayName { get; set; }
 }

--- a/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
+++ b/Src/Fido2.Models/Objects/CredentialPropertiesOutput.cs
@@ -17,6 +17,7 @@ public class CredentialPropertiesOutput
 
     /// <summary>
     /// This OPTIONAL property is a human-palatable description of the credential’s managing authenticator, chosen by the user.
+    /// https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname
     /// </summary>
     [JsonPropertyName("authenticatorDisplayName")]
     public string? AuthenticatorDisplayName { get; set; }


### PR DESCRIPTION
Based on the current editors draft on https://w3c.github.io/webauthn/ a new field `authenticatorDisplayName` has been added: https://w3c.github.io/webauthn/#dom-credentialpropertiesoutput-authenticatordisplayname

Thought it would be feasible to add this field, since it provides valuable information :)