### PR TITLE
[#534] Demo project js makemakeAssertionOptions status changed to error

### DIFF
--- a/Demo/wwwroot/js/custom.login.js
+++ b/Demo/wwwroot/js/custom.login.js
@@ -30,7 +30,7 @@ async function handleSignInSubmit(event) {
     console.log("Assertion Options Object", makeAssertionOptions);
 
     // show options error to user
-    if (makeAssertionOptions.status !== "ok") {
+    if (makeAssertionOptions.status === "error") {
         console.log("Error creating assertion options");
         console.log(makeAssertionOptions.errorMessage);
         showErrorAlert(makeAssertionOptions.errorMessage);

--- a/Demo/wwwroot/js/mfa.login.js
+++ b/Demo/wwwroot/js/mfa.login.js
@@ -35,7 +35,7 @@ async function handleSignInSubmit(event) {
     console.log("Assertion Options Object", makeAssertionOptions);
 
     // show options error to user
-    if (makeAssertionOptions.status !== "ok") {
+    if (makeAssertionOptions.status === "error") {
         console.log("Error creating assertion options");
         console.log(makeAssertionOptions.errorMessage);
         showErrorAlert(makeAssertionOptions.errorMessage);

--- a/Demo/wwwroot/js/passwordless.login.js
+++ b/Demo/wwwroot/js/passwordless.login.js
@@ -28,7 +28,7 @@ async function handleSignInSubmit(event) {
     console.log("Assertion Options Object", makeAssertionOptions);
 
     // show options error to user
-    if (makeAssertionOptions.status !== "ok") {
+    if (makeAssertionOptions.status === "error") {
         console.log("Error creating assertion options");
         console.log(makeAssertionOptions.errorMessage);
         showErrorAlert(makeAssertionOptions.errorMessage);

--- a/Demo/wwwroot/js/passwordless.register.js
+++ b/Demo/wwwroot/js/passwordless.register.js
@@ -42,7 +42,7 @@ async function handleRegisterSubmit(event) {
 
     console.log("Credential Options Object", makeCredentialOptions);
 
-    if (makeCredentialOptions.status !== "ok") {
+    if (makeCredentialOptions.status === "error") {
         console.log("Error creating credential options");
         console.log(makeCredentialOptions.errorMessage);
         showErrorAlert(makeCredentialOptions.errorMessage);

--- a/Demo/wwwroot/js/usernameless.login.js
+++ b/Demo/wwwroot/js/usernameless.login.js
@@ -28,7 +28,7 @@ async function handleSignInSubmit(event) {
     console.log("Assertion Options Object", makeAssertionOptions);
 
     // show options error to user
-    if (makeAssertionOptions.status !== "ok") {
+    if (makeAssertionOptions.status === "error") {
         console.log("Error creating assertion options");
         console.log(makeAssertionOptions.errorMessage);
         showErrorAlert(makeAssertionOptions.errorMessage);


### PR DESCRIPTION
On Demo project, We found when trying to open demo some js error occures. 
We changed status code for `makemakeAssertionOptions.status`  !== 'ok' to === 'error'

Fully qualified demo, make sure we need to add https redirect on projects. It will also getting this error with the same way so, needs to maintain to HttpsRedirections

https://www.rfc-editor.org/rfc/rfc6454

Also related with this issue
https://github.com/passwordless-lib/fido2-net-lib/issues/534