### PR TITLE
`FidoEnumConverter`: fall back to deserializing by name even if `EnumMemberAttribute` is set

### DIFF
--- a/Src/Fido2.Models/Converters/FidoEnumConverter.cs
+++ b/Src/Fido2.Models/Converters/FidoEnumConverter.cs
@@ -12,23 +12,36 @@ public sealed class FidoEnumConverter<[DynamicallyAccessedMembers(DynamicallyAcc
         switch (reader.TokenType)
         {
             case JsonTokenType.String:
-                string text = reader.GetString();
-                if (EnumNameMapper<T>.TryGetValue(text, out T value))
-                    return value;
-                else
-                    throw new JsonException($"Invalid enum value = \"{text}\"");
+            {
+                var text = reader.GetString();
+
+                // Map to an enum value using the EnumMemberAttribute
+                if (EnumNameMapper<T>.TryGetValue(text, out var valueByMemberName))
+                    return valueByMemberName;
+
+                // Map to an enum value directly by name
+                if (Enum.TryParse<T>(text, true, out var valueByName))
+                    return valueByName;
+
+                throw new JsonException($"Invalid enum value = \"{text}\"");
+            }
 
             case JsonTokenType.Number:
+            {
                 if (!reader.TryGetInt32(out var number))
                     throw new JsonException($"Invalid enum value = {reader.GetString()}");
-                var casted = (T)(object)number; // ints can always be casted to enum, even when the value is not defined
+
+                var casted = (T)(object)number; // ints can always be cast to enum, even when the value is not defined
                 if (Enum.IsDefined(casted))
                     return casted;
-                else
-                    throw new JsonException($"Invalid enum value = {number}");
+
+                throw new JsonException($"Invalid enum value = {number}");
+            }
 
             default:
+            {
                 throw new JsonException($"Invalid enum value ({reader.TokenType})");
+            }
         }
     }
 

--- a/Test/Converters/FidoEnumConverterTests.cs
+++ b/Test/Converters/FidoEnumConverterTests.cs
@@ -23,10 +23,12 @@ public class FidoEnumConverterTests
     {
         Assert.Equal("\"A\"", JsonSerializer.Serialize(ABC.A));
         Assert.Equal(ABC.A, JsonSerializer.Deserialize<ABC>("\"A\""));
+        Assert.Equal(PublicKeyCredentialType.PublicKey, JsonSerializer.Deserialize<PublicKeyCredentialType>("\"PublicKey\""));
 
         // Case insensitive
         Assert.Equal("\"A\"", JsonSerializer.Serialize(ABC.A));
         Assert.Equal(ABC.A, JsonSerializer.Deserialize<ABC>("\"a\""));
+        Assert.Equal(PublicKeyCredentialType.PublicKey, JsonSerializer.Deserialize<PublicKeyCredentialType>("\"publickey\""));
     }
 
     [Fact]


### PR DESCRIPTION
Currently, `FidoEnumConverter` works in the following way:

1. If an enum value is annotated by `EnumMemberAttribute`, then the provided custom name is used both for serialization and deserialization.
2. If the attribute is absent, then the default name (i.e. field name) is used.

This PR adds another fallback layer:

3. If an enum value is annotated by `EnumMemberAttribute`, but the default name is provided (not custom) then the deserialization would still succeed. Serialization will work the same regardless.

In other words, it would correctly resolve `PublicKeyCredentialType.PublicKey` from both `public-key`, as well as `PublicKey`.

This makes it a bit easier for applications to use Fido2 types directly in their payloads without building their own converters, and without relying on the intricacies of Fido2 naming conventions.