### PR TITLE
Conformance fix: Remove trustpath subject-issuer comparison

### DIFF
--- a/Src/Fido2/Extensions/CryptoUtils.cs
+++ b/Src/Fido2/Extensions/CryptoUtils.cs
@@ -61,7 +61,7 @@ internal static class CryptoUtils
         // Let's check the simplest case first.  If subject and issuer are the same, and the attestation cert is in the list, that's all the validation we need
 
         // We have the same singular root cert in trustpath and it is in attestationRootCertificates
-        if (trustPath.Length == 1 && trustPath[0].Subject.Equals(trustPath[0].Issuer, StringComparison.Ordinal))
+        if (trustPath.Length == 1)
         {
             foreach (X509Certificate2 cert in attestationRootCertificates)
             {

--- a/Test/CryptoUtilsTests.cs
+++ b/Test/CryptoUtilsTests.cs
@@ -66,8 +66,8 @@ public class CryptoUtilsTests
 
         Assert.False(0 == attestationRootCertificates[0].Issuer.CompareTo(attestationRootCertificates[0].Subject));
         Assert.True(CryptoUtils.ValidateTrustChain(trustPath, attestationRootCertificates));
-        Assert.False(CryptoUtils.ValidateTrustChain(trustPath, trustPath));
-        Assert.False(CryptoUtils.ValidateTrustChain(attestationRootCertificates, attestationRootCertificates));
+        Assert.True(CryptoUtils.ValidateTrustChain(trustPath, trustPath));
+        Assert.True(CryptoUtils.ValidateTrustChain(attestationRootCertificates, attestationRootCertificates));
         Assert.False(CryptoUtils.ValidateTrustChain(attestationRootCertificates, trustPath));
     }
 


### PR DESCRIPTION
This was originally written by @googyi (in #456), but due to lack of review in #531 we couldn't merge it.

@googyi Could you help explain this change?

[Notworthy comment](https://github.com/passwordless-lib/fido2-net-lib/pull/531#discussion_r1688633508) from @aseigler:

> The check to see if the subject and the issuer are the same is based on logic described in [datatracker.ietf.org/doc/html/rfc5280#section-3.2](https://datatracker.ietf.org/doc/html/rfc5280#section-3.2). I thought we had already covered this before, where the batch certificate referenced in the metadata is not a root...I'll have to review this more thoroughly.
