### PR TITLE
Wrap arguments into classes

### DIFF
--- a/BlazorWasmDemo/Server/Controllers/UserController.cs
+++ b/BlazorWasmDemo/Server/Controllers/UserController.cs
@@ -150,7 +150,12 @@ public class UserController : ControllerBase
             // 2. Create callback so that lib can verify credential id is unique to this user
 
             // 3. Verify and make the credentials
-            var credential = await _fido2.MakeNewCredentialAsync(attestationResponse, options, CredentialIdUniqueToUserAsync, cancellationToken: cancellationToken);
+            var credential = await _fido2.MakeNewCredentialAsync(new MakeNewCredentialParams
+            {
+                AttestationResponse = attestationResponse,
+                OriginalOptions = options,
+                IsCredentialIdUniqueToUserCallback = CredentialIdUniqueToUserAsync
+            }, cancellationToken: cancellationToken);
 
             // 4. Store the credentials in db
             _demoStorage.AddCredentialToUser(options.User, new StoredCredential
@@ -266,14 +271,15 @@ public class UserController : ControllerBase
             var creds = _demoStorage.GetCredentialById(clientResponse.Id) ?? throw new Exception("Unknown credentials");
 
             // 3. Make the assertion
-            var res = await _fido2.MakeAssertionAsync(
-                clientResponse,
-                options,
-                creds.PublicKey,
-                creds.DevicePublicKeys,
-                creds.SignCount,
-                UserHandleOwnerOfCredentialIdAsync,
-                cancellationToken: cancellationToken);
+            var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams
+            {
+                AssertionResponse = clientResponse,
+                OriginalOptions = options, 
+                StoredPublicKey = creds.PublicKey,
+                StoredSignatureCounter = creds.SignCount,
+                IsUserHandleOwnerOfCredentialIdCallback = UserHandleOwnerOfCredentialIdAsync,
+                StoredDevicePublicKeys = creds.DevicePublicKeys
+            }, cancellationToken: cancellationToken);
 
             // 4. Store the updated counter
             _demoStorage.UpdateCounter(res.CredentialId, res.SignCount);

--- a/BlazorWasmDemo/Server/Controllers/UserController.cs
+++ b/BlazorWasmDemo/Server/Controllers/UserController.cs
@@ -274,7 +274,7 @@ public class UserController : ControllerBase
             var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams
             {
                 AssertionResponse = clientResponse,
-                OriginalOptions = options, 
+                OriginalOptions = options,
                 StoredPublicKey = creds.PublicKey,
                 StoredSignatureCounter = creds.SignCount,
                 IsUserHandleOwnerOfCredentialIdCallback = UserHandleOwnerOfCredentialIdAsync,

--- a/Demo/Controller.cs
+++ b/Demo/Controller.cs
@@ -209,7 +209,8 @@ public class MyController : Controller
             };
 
             // 5. Make the assertion
-            var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams {
+            var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams
+            {
                 AssertionResponse = clientResponse,
                 OriginalOptions = options,
                 StoredPublicKey = creds.PublicKey,

--- a/Demo/Controller.cs
+++ b/Demo/Controller.cs
@@ -106,7 +106,12 @@ public class MyController : Controller
             };
 
             // 2. Verify and make the credentials
-            var credential = await _fido2.MakeNewCredentialAsync(attestationResponse, options, callback, cancellationToken: cancellationToken);
+            var credential = await _fido2.MakeNewCredentialAsync(new MakeNewCredentialParams
+            {
+                AttestationResponse = attestationResponse,
+                OriginalOptions = options,
+                IsCredentialIdUniqueToUserCallback = callback
+            }, cancellationToken: cancellationToken);
 
             // 3. Store the credentials in db
             DemoStorage.AddCredentialToUser(options.User, new StoredCredential
@@ -204,7 +209,14 @@ public class MyController : Controller
             };
 
             // 5. Make the assertion
-            var res = await _fido2.MakeAssertionAsync(clientResponse, options, creds.PublicKey, creds.DevicePublicKeys, storedCounter, callback, cancellationToken: cancellationToken);
+            var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams {
+                AssertionResponse = clientResponse,
+                OriginalOptions = options,
+                StoredPublicKey = creds.PublicKey,
+                StoredSignatureCounter = storedCounter,
+                IsUserHandleOwnerOfCredentialIdCallback = callback,
+                StoredDevicePublicKeys = creds.DevicePublicKeys
+            }, cancellationToken: cancellationToken);
 
             // 6. Store the updated counter
             DemoStorage.UpdateCounter(res.CredentialId, res.SignCount);

--- a/Demo/TestController.cs
+++ b/Demo/TestController.cs
@@ -95,7 +95,12 @@ public class TestController : Controller
         };
 
         // 2. Verify and make the credentials
-        var credential = await _fido2.MakeNewCredentialAsync(attestationResponse, options, callback, cancellationToken: cancellationToken);
+        var credential = await _fido2.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = attestationResponse,
+            OriginalOptions = options,
+            IsCredentialIdUniqueToUserCallback = callback
+        }, cancellationToken: cancellationToken);
 
         // 3. Store the credentials in db
         _demoStorage.AddCredentialToUser(options.User, new StoredCredential
@@ -177,7 +182,15 @@ public class TestController : Controller
         };
 
         // 5. Make the assertion
-        var res = await _fido2.MakeAssertionAsync(clientResponse, options, creds.PublicKey, creds.DevicePublicKeys, storedCounter, callback, cancellationToken: cancellationToken);
+        var res = await _fido2.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = clientResponse,
+            OriginalOptions = options,
+            StoredPublicKey = creds.PublicKey,
+            StoredSignatureCounter = storedCounter,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = creds.DevicePublicKeys
+        }, cancellationToken: cancellationToken);
 
         // 6. Store the updated counter
         _demoStorage.UpdateCounter(res.CredentialId, res.SignCount);

--- a/Src/Fido2/Fido2.cs
+++ b/Src/Fido2/Fido2.cs
@@ -62,7 +62,7 @@ public class Fido2 : IFido2
     /// <summary>
     /// Verifies the response from the browser/authenticator after creating new credentials.
     /// </summary>
-    /// <param name="makeNewCredentialParams">Wraps the input parameters for making a new credential</param>
+    /// <param name="makeNewCredentialParams">The input arguments for creating a passkey</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns></returns>
     public async Task<RegisteredPublicKeyCredential> MakeNewCredentialAsync(MakeNewCredentialParams makeNewCredentialParams,
@@ -94,7 +94,7 @@ public class Fido2 : IFido2
     /// <summary>
     /// Verifies the assertion response from the browser/authenticator to assert existing credentials and authenticate a user.
     /// </summary>
-    /// <param name="makeAssertionParams">Wraps the input arguments for asserting a passkey</param>
+    /// <param name="makeAssertionParams">The input arguments for asserting a passkey</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns></returns>
     public async Task<VerifyAssertionResult> MakeAssertionAsync(MakeAssertionParams makeAssertionParams,

--- a/Src/Fido2/Fido2.cs
+++ b/Src/Fido2/Fido2.cs
@@ -62,21 +62,14 @@ public class Fido2 : IFido2
     /// <summary>
     /// Verifies the response from the browser/authenticator after creating new credentials.
     /// </summary>
-    /// <param name="attestationResponse">The attestation response from the authenticator.</param>
-    /// <param name="originalOptions">The original options that was sent to the client.</param>
-    /// <param name="isCredentialIdUniqueToUser">The delegate used to validate that the CredentialID is unique to this user.</param>
-    /// <param name="requestTokenBindingId">DO NOT USE - Deprecated, but kept in code due to conformance testing tool</param>
+    /// <param name="makeNewCredentialParams">Wraps the input parameters for making a new credential</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns></returns>
-    public async Task<RegisteredPublicKeyCredential> MakeNewCredentialAsync(
-        AuthenticatorAttestationRawResponse attestationResponse,
-        CredentialCreateOptions originalOptions,
-        IsCredentialIdUniqueToUserAsyncDelegate isCredentialIdUniqueToUser,
-        byte[]? requestTokenBindingId = null,
+    public async Task<RegisteredPublicKeyCredential> MakeNewCredentialAsync(MakeNewCredentialParams makeNewCredentialParams,
         CancellationToken cancellationToken = default)
     {
-        var parsedResponse = AuthenticatorAttestationResponse.Parse(attestationResponse);
-        var credential = await parsedResponse.VerifyAsync(originalOptions, _config, isCredentialIdUniqueToUser, _metadataService, requestTokenBindingId, cancellationToken);
+        var parsedResponse = AuthenticatorAttestationResponse.Parse(makeNewCredentialParams.AttestationResponse);
+        var credential = await parsedResponse.VerifyAsync(makeNewCredentialParams.OriginalOptions, _config, makeNewCredentialParams.IsCredentialIdUniqueToUserCallback, _metadataService, makeNewCredentialParams.RequestTokenBindingId, cancellationToken);
 
         return credential;
     }
@@ -101,35 +94,22 @@ public class Fido2 : IFido2
     /// <summary>
     /// Verifies the assertion response from the browser/authenticator to assert existing credentials and authenticate a user.
     /// </summary>
-    /// <param name="assertionResponse">The assertion response from the authenticator.</param>
-    /// <param name="originalOptions">The original options that was sent to the client.</param>
-    /// <param name="storedPublicKey">The stored credential public key.</param>
-    /// <param name="storedDevicePublicKeys">The stored device public keys.</param>
-    /// <param name="storedSignatureCounter">The stored value of the signature counter.</param>
-    /// <param name="isUserHandleOwnerOfCredentialIdCallback">The delegate used to validate that the user handle is indeed owned of the CredentialId.</param>
-    /// <param name="requestTokenBindingId">DO NOT USE - Deprecated, but kept in code due to conformance testing tool</param>
+    /// <param name="makeAssertionParams">Wraps the input arguments for asserting a passkey</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns></returns>
-    public async Task<VerifyAssertionResult> MakeAssertionAsync(
-        AuthenticatorAssertionRawResponse assertionResponse,
-        AssertionOptions originalOptions,
-        byte[] storedPublicKey,
-        IReadOnlyList<byte[]> storedDevicePublicKeys,
-        uint storedSignatureCounter,
-        IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredentialIdCallback,
-        byte[]? requestTokenBindingId = null,
+    public async Task<VerifyAssertionResult> MakeAssertionAsync(MakeAssertionParams makeAssertionParams,
         CancellationToken cancellationToken = default)
     {
-        var parsedResponse = AuthenticatorAssertionResponse.Parse(assertionResponse);
+        var parsedResponse = AuthenticatorAssertionResponse.Parse(makeAssertionParams.AssertionResponse);
 
-        var result = await parsedResponse.VerifyAsync(originalOptions,
+        var result = await parsedResponse.VerifyAsync(makeAssertionParams.OriginalOptions,
                                                       _config,
-                                                      storedPublicKey,
-                                                      storedDevicePublicKeys,
-                                                      storedSignatureCounter,
-                                                      isUserHandleOwnerOfCredentialIdCallback,
+                                                      makeAssertionParams.StoredPublicKey,
+                                                      makeAssertionParams.StoredDevicePublicKeys,
+                                                      makeAssertionParams.StoredSignatureCounter,
+                                                      makeAssertionParams.IsUserHandleOwnerOfCredentialIdCallback,
                                                       _metadataService,
-                                                      requestTokenBindingId,
+                                                      makeAssertionParams.RequestTokenBindingId,
                                                       cancellationToken);
 
         return result;

--- a/Src/Fido2/IFido2.cs
+++ b/Src/Fido2/IFido2.cs
@@ -13,21 +13,10 @@ public interface IFido2
         UserVerificationRequirement? userVerification,
         AuthenticationExtensionsClientInputs? extensions = null);
 
-    Task<VerifyAssertionResult> MakeAssertionAsync(
-        AuthenticatorAssertionRawResponse assertionResponse,
-        AssertionOptions originalOptions,
-        byte[] storedPublicKey,
-        IReadOnlyList<byte[]> storedDevicePublicKeys,
-        uint storedSignatureCounter,
-        IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredentialIdCallback,
-        byte[]? requestTokenBindingId = null,
+    Task<VerifyAssertionResult> MakeAssertionAsync(MakeAssertionParams makeAssertionParams,
         CancellationToken cancellationToken = default);
 
-    Task<RegisteredPublicKeyCredential> MakeNewCredentialAsync(
-        AuthenticatorAttestationRawResponse attestationResponse,
-        CredentialCreateOptions originalOptions,
-        IsCredentialIdUniqueToUserAsyncDelegate isCredentialIdUniqueToUser,
-        byte[]? requestTokenBindingId = null,
+    Task<RegisteredPublicKeyCredential> MakeNewCredentialAsync(MakeNewCredentialParams makeNewCredentialParams,
         CancellationToken cancellationToken = default);
 
     CredentialCreateOptions RequestNewCredential(

--- a/Src/Fido2/MakeAssertionParams.cs
+++ b/Src/Fido2/MakeAssertionParams.cs
@@ -11,7 +11,7 @@ public class MakeAssertionParams
     /// <summary>
     /// The assertion response from the authenticator.
     /// </summary>
-    public required  AuthenticatorAssertionRawResponse AssertionResponse { get; init; }
+    public required AuthenticatorAssertionRawResponse AssertionResponse { get; init; }
 
     /// <summary>
     /// The original options that was sent to the client.
@@ -22,7 +22,7 @@ public class MakeAssertionParams
     /// The stored credential public key.
     /// </summary>
     public required byte[] StoredPublicKey { get; init; }
-    
+
     /// <summary>
     /// The stored value of the signature counter.
     /// </summary>
@@ -36,7 +36,7 @@ public class MakeAssertionParams
     /// <summary>
     /// The stored device public keys.
     /// </summary>
-    public IReadOnlyList<byte[]> StoredDevicePublicKeys { get;  init; } = Array.Empty<byte[]>();
+    public IReadOnlyList<byte[]> StoredDevicePublicKeys { get; init; } = Array.Empty<byte[]>();
 
 
     /// <summary>

--- a/Src/Fido2/MakeAssertionParams.cs
+++ b/Src/Fido2/MakeAssertionParams.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Fido2NetLib;
+
+/// <summary>
+/// Wraps the input for the MakeAssertion function
+/// </summary>
+public class MakeAssertionParams
+{
+    /// <summary>
+    /// The assertion response from the authenticator.
+    /// </summary>
+    public required  AuthenticatorAssertionRawResponse AssertionResponse { get; init; }
+
+    /// <summary>
+    /// The original options that was sent to the client.
+    /// </summary>
+    public required AssertionOptions OriginalOptions { get; init; }
+
+    /// <summary>
+    /// The stored credential public key.
+    /// </summary>
+    public required byte[] StoredPublicKey { get; init; }
+    
+    /// <summary>
+    /// The stored value of the signature counter.
+    /// </summary>
+    public required uint StoredSignatureCounter { get; init; }
+
+    /// <summary>
+    /// The delegate used to validate that the user handle is indeed owned of the CredentialId.
+    /// </summary>
+    public required IsUserHandleOwnerOfCredentialIdAsync IsUserHandleOwnerOfCredentialIdCallback { get; init; }
+
+    /// <summary>
+    /// The stored device public keys.
+    /// </summary>
+    public IReadOnlyList<byte[]> StoredDevicePublicKeys { get;  init; } = Array.Empty<byte[]>();
+
+
+    /// <summary>
+    /// DO NOT USE - Deprecated, but kept in code due to conformance testing tool.
+    /// </summary>
+    public byte[]? RequestTokenBindingId { get; init; }
+}

--- a/Src/Fido2/MakeAssertionParams.cs
+++ b/Src/Fido2/MakeAssertionParams.cs
@@ -6,7 +6,7 @@ namespace Fido2NetLib;
 /// <summary>
 /// Wraps the input for the MakeAssertion function
 /// </summary>
-public class MakeAssertionParams
+public sealed class MakeAssertionParams
 {
     /// <summary>
     /// The assertion response from the authenticator.

--- a/Src/Fido2/MakeAssertionParams.cs
+++ b/Src/Fido2/MakeAssertionParams.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Fido2NetLib;
 
@@ -38,9 +39,9 @@ public sealed class MakeAssertionParams
     /// </summary>
     public IReadOnlyList<byte[]> StoredDevicePublicKeys { get; init; } = Array.Empty<byte[]>();
 
-
     /// <summary>
     /// DO NOT USE - Deprecated, but kept in code due to conformance testing tool.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public byte[]? RequestTokenBindingId { get; init; }
 }

--- a/Src/Fido2/MakeNewCredentialParams.cs
+++ b/Src/Fido2/MakeNewCredentialParams.cs
@@ -13,7 +13,7 @@ public class MakeNewCredentialParams
     /// <summary>
     ///  The original options that was sent to the client.
     /// </summary>
-    public required CredentialCreateOptions OriginalOptions { get;  init; }
+    public required CredentialCreateOptions OriginalOptions { get; init; }
 
     /// <summary>
     ///  The delegate used to validate that the CredentialID is unique to this user.

--- a/Src/Fido2/MakeNewCredentialParams.cs
+++ b/Src/Fido2/MakeNewCredentialParams.cs
@@ -1,4 +1,6 @@
-﻿namespace Fido2NetLib;
+﻿using System.ComponentModel;
+
+namespace Fido2NetLib;
 
 /// <summary>
 /// Wraps the input for the MakeNewCredential function
@@ -23,5 +25,6 @@ public sealed class MakeNewCredentialParams
     /// <summary>
     ///  DO NOT USE - Deprecated, but kept in code due to conformance testing tool
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public byte[]? RequestTokenBindingId { get; init; }
 }

--- a/Src/Fido2/MakeNewCredentialParams.cs
+++ b/Src/Fido2/MakeNewCredentialParams.cs
@@ -1,0 +1,27 @@
+﻿namespace Fido2NetLib;
+
+/// <summary>
+/// Wraps the input for the MakeNewCredential function
+/// </summary>
+public class MakeNewCredentialParams
+{
+    /// <summary>
+    ///  The attestation response from the authenticator.
+    /// </summary>
+    public required AuthenticatorAttestationRawResponse AttestationResponse { get; init; }
+
+    /// <summary>
+    ///  The original options that was sent to the client.
+    /// </summary>
+    public required CredentialCreateOptions OriginalOptions { get;  init; }
+
+    /// <summary>
+    ///  The delegate used to validate that the CredentialID is unique to this user.
+    /// </summary>
+    public required IsCredentialIdUniqueToUserAsyncDelegate IsCredentialIdUniqueToUserCallback { get; init; }
+
+    /// <summary>
+    ///  DO NOT USE - Deprecated, but kept in code due to conformance testing tool
+    /// </summary>
+    public byte[]? RequestTokenBindingId { get; init; }
+}

--- a/Src/Fido2/MakeNewCredentialParams.cs
+++ b/Src/Fido2/MakeNewCredentialParams.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Wraps the input for the MakeNewCredential function
 /// </summary>
-public class MakeNewCredentialParams
+public sealed class MakeNewCredentialParams
 {
     /// <summary>
     ///  The attestation response from the authenticator.

--- a/Tests/Fido2.Tests/Attestation/Apple.cs
+++ b/Tests/Fido2.Tests/Attestation/Apple.cs
@@ -269,7 +269,12 @@ public class Apple : Fido2Tests.Attestation
             Origins = new HashSet<string> { "https://www.passwordless.dev" },
         });
 
-        var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, originalOptions, callback);
+        var credentialMakeResult = await lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = attestationResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        });
     }
 
     private string[] StackAllocSha256(ReadOnlySpan<byte> authData, ReadOnlySpan<byte> clientDataJson)

--- a/Tests/Fido2.Tests/AuthenticatorResponse.cs
+++ b/Tests/Fido2.Tests/AuthenticatorResponse.cs
@@ -123,7 +123,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { expectedOrigin },
         });
 
-        var result = await lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback);
+        var result = await lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        });
     }
 
     [Theory]
@@ -224,7 +229,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { expectedOrigin },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.StartsWith("Fully qualified origin", ex.Message);
     }
 
@@ -433,7 +443,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Same(Fido2ErrorMessages.AttestationResponseTypeNotWebAuthnGet, ex.Message);
     }
 
@@ -503,7 +518,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Same(Fido2ErrorMessages.AttestationResponseIdMissing, ex.Message);
     }
 
@@ -571,7 +591,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal("AttestationResponse type must be 'public-key'", ex.Message);
     }
 
@@ -646,7 +671,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal(Fido2ErrorCode.InvalidRpidHash, ex.Code);
         Assert.Equal(Fido2ErrorMessages.InvalidRpidHash, ex.Message);
     }
@@ -723,7 +753,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
 
         Assert.Equal(Fido2ErrorCode.UserPresentFlagNotSet, ex.Code);
         Assert.Equal(Fido2ErrorMessages.UserPresentFlagNotSet, ex.Message);
@@ -801,7 +836,12 @@ public class AuthenticatorResponseTests
             BackupEligibleCredentialPolicy = Fido2Configuration.CredentialBackupPolicy.Required,
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupEligibilityRequirementNotMet, ex.Message);
     }
 
@@ -877,7 +917,12 @@ public class AuthenticatorResponseTests
             BackupEligibleCredentialPolicy = Fido2Configuration.CredentialBackupPolicy.Disallowed,
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupEligibilityRequirementNotMet, ex.Message);
     }
 
@@ -952,7 +997,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal("Attestation flag not set on attestation data", ex.Message);
     }
 
@@ -1028,7 +1078,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal("Unknown attestation type. Was 'testing'", ex.Message);
         Assert.Equal(Fido2ErrorCode.UnknownAttestationType, ex.Code);
     }
@@ -1104,7 +1159,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal("CredentialId is not unique to this user", ex.Message);
     }
 
@@ -1179,7 +1239,12 @@ public class AuthenticatorResponseTests
             Origins = new HashSet<string> { rp },
         });
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(rawResponse, originalOptions, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+        {
+            AttestationResponse = rawResponse,
+            OriginalOptions = originalOptions,
+            IsCredentialIdUniqueToUserCallback = callback
+        }));
         Assert.Equal("User Verified flag not set in authenticator data and user verification was required", ex.Message);
     }
 
@@ -1313,7 +1378,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.AssertionResponseNotPublicKey, ex.Message);
     }
 
@@ -1381,7 +1454,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.AssertionResponseIdMissing, ex.Message);
     }
 
@@ -1450,7 +1531,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.AssertionResponseRawIdMissing, ex.Message);
     }
 
@@ -1519,7 +1608,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.UserHandleIsEmpty, ex.Message);
     }
 
@@ -1588,7 +1685,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(false);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.UserHandleNotOwnerOfPublicKey, ex.Message);
     }
 
@@ -1657,7 +1762,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.AssertionResponseTypeNotWebAuthnGet, ex.Message);
     }
 
@@ -1728,7 +1841,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.InvalidRpidHash, ex.Message);
     }
 
@@ -1798,7 +1919,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.InvalidRpidHash, ex.Message);
     }
 
@@ -1868,7 +1997,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.UserPresentFlagNotSet, ex.Message);
     }
 
@@ -1938,7 +2075,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.UserVerificationRequirementNotMet, ex.Message);
     }
 
@@ -2007,7 +2152,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupEligibilityRequirementNotMet, ex.Message);
     }
 
@@ -2076,7 +2229,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupEligibilityRequirementNotMet, ex.Message);
     }
 
@@ -2145,7 +2306,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupStateRequirementNotMet, ex.Message);
     }
 
@@ -2214,7 +2383,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.BackupStateRequirementNotMet, ex.Message);
     }
 
@@ -2283,7 +2460,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, null, null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = null,
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.MissingStoredPublicKey, ex.Message);
     }
 
@@ -2353,7 +2538,15 @@ public class AuthenticatorResponseTests
         };
 
         fido2_net_lib.Test.Fido2Tests.MakeEdDSA(out _, out var publicKey, out var privateKey);
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, fido2_net_lib.Test.Fido2Tests.MakeCredentialPublicKey(COSE.KeyType.OKP, COSE.Algorithm.EdDSA, COSE.EllipticCurve.Ed25519, publicKey).GetBytes(), null, 0, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = fido2_net_lib.Test.Fido2Tests.MakeCredentialPublicKey(COSE.KeyType.OKP, COSE.Algorithm.EdDSA, COSE.EllipticCurve.Ed25519, publicKey).GetBytes(),
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.InvalidSignature, ex.Message);
     }
 
@@ -2428,7 +2621,15 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(assertionResponse, options, cpk.GetBytes(), null, 2, callback));
+        var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = assertionResponse,
+            OriginalOptions = options,
+            StoredPublicKey = cpk.GetBytes(),
+            StoredSignatureCounter = 2,
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredDevicePublicKeys = null
+        }));
         Assert.Equal(Fido2ErrorMessages.SignCountIsLessThanSignatureCounter, ex.Message);
     }
 }

--- a/Tests/Fido2.Tests/ExistingU2fRegistrationDataTests.cs
+++ b/Tests/Fido2.Tests/ExistingU2fRegistrationDataTests.cs
@@ -55,7 +55,15 @@ public class ExistingU2fRegistrationDataTests
             Origins = new HashSet<string> { "https://localhost:44336" } //data was generated with this origin
         });
 
-        var credential = await fido2.MakeAssertionAsync(authResponse, options, publicKey.Encode(), null, 0, null);
+        var credential = await fido2.MakeAssertionAsync(new MakeAssertionParams {
+        
+            AssertionResponse = authResponse,
+            OriginalOptions = options,
+            StoredPublicKey = publicKey.Encode(),
+            StoredSignatureCounter = 0,
+            IsUserHandleOwnerOfCredentialIdCallback = null,
+            StoredDevicePublicKeys = null
+        });
 
         Assert.NotEmpty(credential.CredentialId);
     }

--- a/Tests/Fido2.Tests/ExistingU2fRegistrationDataTests.cs
+++ b/Tests/Fido2.Tests/ExistingU2fRegistrationDataTests.cs
@@ -55,8 +55,9 @@ public class ExistingU2fRegistrationDataTests
             Origins = new HashSet<string> { "https://localhost:44336" } //data was generated with this origin
         });
 
-        var credential = await fido2.MakeAssertionAsync(new MakeAssertionParams {
-        
+        var credential = await fido2.MakeAssertionAsync(new MakeAssertionParams
+        {
+
             AssertionResponse = authResponse,
             OriginalOptions = options,
             StoredPublicKey = publicKey.Encode(),

--- a/Tests/Fido2.Tests/Fido2Tests.cs
+++ b/Tests/Fido2.Tests/Fido2Tests.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;

--- a/Tests/Fido2.Tests/Fido2Tests.cs
+++ b/Tests/Fido2.Tests/Fido2Tests.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
@@ -237,7 +237,12 @@ public class Fido2Tests
                 Origins = new HashSet<string> { rp },
             });
 
-            var credentialMakeResult = await lib.MakeNewCredentialAsync(attestationResponse, originalOptions, callback);
+            var credentialMakeResult = await lib.MakeNewCredentialAsync(new MakeNewCredentialParams
+            {
+                AttestationResponse = attestationResponse,
+                OriginalOptions = originalOptions,
+                IsCredentialIdUniqueToUserCallback = callback
+            });
 
             return credentialMakeResult;
         }
@@ -988,7 +993,14 @@ public class Fido2Tests
         {
             return Task.FromResult(true);
         };
-        return await lib.MakeAssertionAsync(response, options, cpk.GetBytes(), null, signCount, callback);
+        return await lib.MakeAssertionAsync(new MakeAssertionParams
+        {
+            AssertionResponse = response,
+            OriginalOptions = options,
+            StoredPublicKey = cpk.GetBytes(),
+            IsUserHandleOwnerOfCredentialIdCallback = callback,
+            StoredSignatureCounter = signCount
+        });
     }
 
     internal static void MakeEdDSA(out byte[] privateKeySeed, out byte[] publicKey, out byte[] expandedPrivateKey)


### PR DESCRIPTION
Reason: In order to make arguments more readable and future API changes less likely to cause binary breaking changes to everyone we're moving many arguments into wrapping classes.

In this PR the classes are suffixed with Params, instead of popular `Options`/`Request` to avoid adding confusion as those terms are used elsewhere as part of webauthn.