### PR TITLE
AuthenticatorSelection Default to discourage UV

### DIFF
--- a/Src/Fido2.Models/CredentialCreateOptions.cs
+++ b/Src/Fido2.Models/CredentialCreateOptions.cs
@@ -281,7 +281,7 @@ public class AuthenticatorSelection
     {
         AuthenticatorAttachment = null,
         ResidentKey = ResidentKeyRequirement.Discouraged,
-        UserVerification = UserVerificationRequirement.Preferred
+        UserVerification = UserVerificationRequirement.Discouraged
     };
 }
 


### PR DESCRIPTION
This PR modifies the default AuthenticatorSelection configuration to discourage User Verification (UV). This change aims to improve the overall user experience for most applications where UV isn't a critical security requirement.

## Rationale

* Most applications don't require User Verification during signing operations
* Disabling UV by default reduces friction in the authentication flow
* Applications that need UV can still explicitly enable it

## Discussion Points
I'd appreciate community feedback on this change, particularly regarding:

* Security implications
* User experience trade-offs
* Specific use cases where this might be problematic

CC: @aseigler @iamcarbon @joegoldman2