### PR TITLE
Move KeyTypeParameter validation from CredentialPublicKey.Verify() into constructors

### DIFF
--- a/Src/Fido2.Models/COSETypes.cs
+++ b/Src/Fido2.Models/COSETypes.cs
@@ -195,6 +195,7 @@ public static class COSE
         {
             "1.2.840.10045.2.1" => KeyType.EC2, // ecPublicKey
             "1.2.840.113549.1.1.1" => KeyType.RSA,
+            "1.3.101.112" => KeyType.OKP,
             _ => throw new Exception($"Unknown oid. Was {oid}")
         };
     }

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -15,33 +15,35 @@ namespace Fido2NetLib;
 
 internal sealed class Tpm : AttestationVerifier
 {
+    private static string ConvertTPMManufacturerToHexString(string id) => BitConverter.ToString(Convert.FromHexString(id.Split(':')[^1]));
+
     public static readonly HashSet<string> TPMManufacturers =
     [
-        "id:FFFFF1D0", // FIDO testing TPM
+        ConvertTPMManufacturerToHexString("id:FFFFF1D0"), // FIDO testing TPM
         // From https://trustedcomputinggroup.org/wp-content/uploads/TCG-TPM-Vendor-ID-Registry-Version-1.02-Revision-1.00.pdf
-        "id:414D4400", // 'AMD' AMD
-        "id:41544D4C", // 'ATML' Atmel
-        "id:4252434D", // 'BRCM' Broadcom
-        "id:4353434F", // 'CSCO' Cisco
-        "id:464C5953", // 'FLYS' Flyslice Technologies
-        "id:48504500", // 'HPE' HPE
-        "id:49424d00", // 'IBM' IBM
-        "id:49465800", // 'IFX' Infinion
-        "id:494E5443", // 'INTC' Intel
-        "id:4C454E00", // 'LEN' Lenovo
-        "id:4D534654", // 'MSFT' Microsoft
-        "id:4E534D20", // 'NSM' National Semiconductor
-        "id:4E545A00", // 'NTZ' Nationz
-        "id:4E544300", // 'NTC' Nuvoton Technology
-        "id:51434F4D", // 'QCOM' Qualcomm
-        "id:534D5343", // 'SMSC' SMSC
-        "id:53544D20", // 'STM ' ST Microelectronics
-        "id:534D534E", // 'SMSN' Samsung
-        "id:534E5300", // 'SNS' Sinosun
-        "id:54584E00", // 'TXN' Texas Instruments
-        "id:57454300", // 'WEC' Winbond
-        "id:524F4343", // 'ROCC' Fuzhou Rockchip
-        "id:474F4F47", // 'GOOG' Google
+        ConvertTPMManufacturerToHexString("id:414D4400"), // 'AMD' AMD
+        ConvertTPMManufacturerToHexString("id:41544D4C"), // 'ATML' Atmel
+        ConvertTPMManufacturerToHexString("id:4252434D"), // 'BRCM' Broadcom
+        ConvertTPMManufacturerToHexString("id:4353434F"), // 'CSCO' Cisco
+        ConvertTPMManufacturerToHexString("id:464C5953"), // 'FLYS' Flyslice Technologies
+        ConvertTPMManufacturerToHexString("id:48504500"), // 'HPE' HPE
+        ConvertTPMManufacturerToHexString("id:49424d00"), // 'IBM' IBM
+        ConvertTPMManufacturerToHexString("id:49465800"), // 'IFX' Infinion
+        ConvertTPMManufacturerToHexString("id:494E5443"), // 'INTC' Intel
+        ConvertTPMManufacturerToHexString("id:4C454E00"), // 'LEN' Lenovo
+        ConvertTPMManufacturerToHexString("id:4D534654"), // 'MSFT' Microsoft
+        ConvertTPMManufacturerToHexString("id:4E534D20"), // 'NSM' National Semiconductor
+        ConvertTPMManufacturerToHexString("id:4E545A00"), // 'NTZ' Nationz
+        ConvertTPMManufacturerToHexString("id:4E544300"), // 'NTC' Nuvoton Technology
+        ConvertTPMManufacturerToHexString("id:51434F4D"), // 'QCOM' Qualcomm
+        ConvertTPMManufacturerToHexString("id:534D5343"), // 'SMSC' SMSC
+        ConvertTPMManufacturerToHexString("id:53544D20"), // 'STM ' ST Microelectronics
+        ConvertTPMManufacturerToHexString("id:534D534E"), // 'SMSN' Samsung
+        ConvertTPMManufacturerToHexString("id:534E5300"), // 'SNS' Sinosun
+        ConvertTPMManufacturerToHexString("id:54584E00"), // 'TXN' Texas Instruments
+        ConvertTPMManufacturerToHexString("id:57454300"), // 'WEC' Winbond
+        ConvertTPMManufacturerToHexString("id:524F4343"), // 'ROCC' Fuzhou Rockchip
+        ConvertTPMManufacturerToHexString("id:474F4F47"), // 'GOOG' Google
     ];
 
     public override ValueTask<VerifyAttestationResult> VerifyAsync(VerifyAttestationRequest request)
@@ -177,7 +179,7 @@ internal sealed class Tpm : AttestationVerifier
                 throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "SAN missing TPMManufacturer, TPMModel, or TPMVersion from TPM attestation certificate");
             }
 
-            if (!TPMManufacturers.Contains(tpmManufacturer))
+            if (!TPMManufacturers.Contains(ConvertTPMManufacturerToHexString(tpmManufacturer)))
                 throw new Fido2VerificationException(Fido2ErrorCode.InvalidAttestation, "Invalid TPM manufacturer found parsing TPM attestation");
 
             // 5biiii. The Extended Key Usage extension MUST contain the "joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.

--- a/Src/Fido2/AttestationFormat/Tpm.cs
+++ b/Src/Fido2/AttestationFormat/Tpm.cs
@@ -15,7 +15,7 @@ namespace Fido2NetLib;
 
 internal sealed class Tpm : AttestationVerifier
 {
-    private static string ConvertTPMManufacturerToHexString(string id) => BitConverter.ToString(Convert.FromHexString(id.Split(':')[^1]));
+    private static string ConvertTPMManufacturerToHexString(string id) => BitConverter.ToString(Convert.FromHexString(id.Split(':')[^1])).Replace("-","");
 
     public static readonly HashSet<string> TPMManufacturers =
     [

--- a/Tests/Fido2.Tests/Attestation/Packed.cs
+++ b/Tests/Fido2.Tests/Attestation/Packed.cs
@@ -442,7 +442,7 @@ public class Packed : Fido2Tests.Attestation
 
         var x5c = new CborArray { attestnCert.RawData, root.RawData };
 
-        var signature = SignData(type, alg, COSE.EllipticCurve.Reserved, ecdsa: ecdsaAtt);
+        var signature = SignData(type, alg, COSE.EllipticCurve.P256, ecdsa: ecdsaAtt);
 
         _attestationObject.Add("attStmt", new CborMap {
             { "alg", alg },
@@ -483,7 +483,7 @@ public class Packed : Fido2Tests.Attestation
 
         var x5c = new CborArray { attestnCert.RawData, root.RawData };
 
-        byte[] signature = SignData(type, alg, COSE.EllipticCurve.Reserved, ecdsa: ecdsaAtt);
+        byte[] signature = SignData(type, alg, COSE.EllipticCurve.P256, ecdsa: ecdsaAtt);
 
         _attestationObject.Add("attStmt", new CborMap {
             { "alg", alg },

--- a/Tests/Fido2.Tests/CredentialPublicKeyTests.cs
+++ b/Tests/Fido2.Tests/CredentialPublicKeyTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Security.Cryptography;
-
+using System.Security.Cryptography.X509Certificates;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
 
@@ -40,8 +40,22 @@ public class CredentialPublicKeyTests
             Assert.Equal(oid, decodedEcDsaParams.Curve.Oid.Value);
         }
 
-
-
         Assert.True(credentialPublicKey.Verify(signedData, signature));
+    }
+
+    [Theory]
+    [InlineData("A501020326200121581F6F56E6590BD91D39744F83A820E8B3FBB6608DA583794091538296D1DA73E2225820B0A65E0B18D3189DA3B4A7036202ADF65A6B68EFF8C24825532D7A04386AE628", 0x80131501)]
+    public void InvalidCoseKey(string str, uint hresult)
+    {
+        var cpkBytes = Convert.FromHexString(str);
+        var ex = Assert.Throws<CryptographicException>(() => new CredentialPublicKey(cpkBytes));
+        Assert.True(((uint)ex.HResult) == hresult);
+    }
+
+    [Fact]
+    public void OkpCertificate()
+    {
+        X509Certificate2 okpCert = new(X509CertificateHelper.CreateFromBase64String("MIIBhTCCATegAwIBAgIUfKk9eVV+OkGNxxguVYluGHPPI+swBQYDK2VwMDgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhGbG9yaWRzYTEWMBQGA1UECgwNRklETzItTkVULUxJQjAeFw0yNDExMDQwMDM3MDNaFw0yNDEyMDQwMDM3MDNaMDgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhGbG9yaWRzYTEWMBQGA1UECgwNRklETzItTkVULUxJQjAqMAUGAytlcAMhAJ2oFxsqEgM4DiMSJNskAYoKf55FXZhrde4Ho2UMJoKuo1MwUTAdBgNVHQ4EFgQUyhKwoqOmiB3UeXztoIPueEi7qSgwHwYDVR0jBBgwFoAUyhKwoqOmiB3UeXztoIPueEi7qSgwDwYDVR0TAQH/BAUwAwEB/zAFBgMrZXADQQArZ82PaihKfiOHNDPCmax/vgsuMlJcQsAywcQFZfaRiNyU5Cq7hwOvNlA1wl1j9hZjV/SiPsfNSgY7nwTGf9cE"u8));
+        CredentialPublicKey cpk = new(okpCert, COSE.Algorithm.EdDSA);
     }
 }


### PR DESCRIPTION
Add test for invalid COSE key types
Add support for OKP certificates for CredentialPublicKey and test for same
Fix two packed tests that erroneously used "Reserved" key type instead of P256

Closes #552