### PR TITLE
Move KeyTypeParameter validation from CredentialPublicKey.Verify() into constructors

### DIFF
--- a/Src/Fido2.Models/COSETypes.cs
+++ b/Src/Fido2.Models/COSETypes.cs
@@ -195,6 +195,7 @@ public static class COSE
         {
             "1.2.840.10045.2.1" => KeyType.EC2, // ecPublicKey
             "1.2.840.113549.1.1.1" => KeyType.RSA,
+            "1.3.101.112" => KeyType.OKP,
             _ => throw new Exception($"Unknown oid. Was {oid}")
         };
     }

--- a/Src/Fido2/Objects/CredentialPublicKey.cs
+++ b/Src/Fido2/Objects/CredentialPublicKey.cs
@@ -101,7 +101,7 @@ public sealed class CredentialPublicKey
                     break;
                 }
             default:
-                throw new InvalidOperationException($"MMissing or unknown kty {_type}");
+                throw new InvalidOperationException($"Missing or unknown kty {_type}");
         }
     }
 

--- a/Src/Fido2/Objects/CredentialPublicKey.cs
+++ b/Src/Fido2/Objects/CredentialPublicKey.cs
@@ -26,20 +26,20 @@ public sealed class CredentialPublicKey
         switch (_type)
         {
             case COSE.KeyType.EC2:
-            {
-                _ecdsa = CreateECDsa();
-                return;
-            }
+                {
+                    _ecdsa = CreateECDsa();
+                    return;
+                }
             case COSE.KeyType.RSA:
-            {
-                _rsa = CreateRSA();
-                return;
-            }
+                {
+                    _rsa = CreateRSA();
+                    return;
+                }
             case COSE.KeyType.OKP:
-            {
-                _eddsa = CreateEdDSA();
-                return;
-            }
+                {
+                    _eddsa = CreateEdDSA();
+                    return;
+                }
         }
         throw new InvalidOperationException($"Missing or unknown kty {_type}");
     }
@@ -75,31 +75,31 @@ public sealed class CredentialPublicKey
         switch (_type)
         {
             case COSE.KeyType.RSA:
-            {
-                var keyParams = cert.GetRSAPublicKey()!.ExportParameters(false);
-                _cpk.Add(COSE.KeyTypeParameter.N, keyParams.Modulus!);
-                _cpk.Add(COSE.KeyTypeParameter.E, keyParams.Exponent!);
-                _rsa = CreateRSA();
-                break;
-            }
+                {
+                    var keyParams = cert.GetRSAPublicKey()!.ExportParameters(false);
+                    _cpk.Add(COSE.KeyTypeParameter.N, keyParams.Modulus!);
+                    _cpk.Add(COSE.KeyTypeParameter.E, keyParams.Exponent!);
+                    _rsa = CreateRSA();
+                    break;
+                }
             case COSE.KeyType.EC2:
-            {
-                var ecDsaPubKey = cert.GetECDsaPublicKey()!;
-                var keyParams = ecDsaPubKey.ExportParameters(false);
+                {
+                    var ecDsaPubKey = cert.GetECDsaPublicKey()!;
+                    var keyParams = ecDsaPubKey.ExportParameters(false);
 
-                _cpk.Add(COSE.KeyTypeParameter.Crv, keyParams.Curve.ToCoseCurve());
-                _cpk.Add(COSE.KeyTypeParameter.X, keyParams.Q.X!);
-                _cpk.Add(COSE.KeyTypeParameter.Y, keyParams.Q.Y!);
-                _ecdsa = CreateECDsa();
-                break;
-            }
+                    _cpk.Add(COSE.KeyTypeParameter.Crv, keyParams.Curve.ToCoseCurve());
+                    _cpk.Add(COSE.KeyTypeParameter.X, keyParams.Q.X!);
+                    _cpk.Add(COSE.KeyTypeParameter.Y, keyParams.Q.Y!);
+                    _ecdsa = CreateECDsa();
+                    break;
+                }
             case COSE.KeyType.OKP:
-            {
-                _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.Ed25519);
-                _cpk.Add(COSE.KeyTypeParameter.X, cert.PublicKey.EncodedKeyValue.RawData);
-                _eddsa = CreateEdDSA();
-                break;
-            }
+                {
+                    _cpk.Add(COSE.KeyTypeParameter.Crv, COSE.EllipticCurve.Ed25519);
+                    _cpk.Add(COSE.KeyTypeParameter.X, cert.PublicKey.EncodedKeyValue.RawData);
+                    _eddsa = CreateEdDSA();
+                    break;
+                }
             default:
                 throw new InvalidOperationException($"MMissing or unknown kty {_type}");
         }

--- a/Tests/Fido2.Tests/Attestation/Packed.cs
+++ b/Tests/Fido2.Tests/Attestation/Packed.cs
@@ -442,7 +442,7 @@ public class Packed : Fido2Tests.Attestation
 
         var x5c = new CborArray { attestnCert.RawData, root.RawData };
 
-        var signature = SignData(type, alg, COSE.EllipticCurve.Reserved, ecdsa: ecdsaAtt);
+        var signature = SignData(type, alg, COSE.EllipticCurve.P256, ecdsa: ecdsaAtt);
 
         _attestationObject.Add("attStmt", new CborMap {
             { "alg", alg },
@@ -483,7 +483,7 @@ public class Packed : Fido2Tests.Attestation
 
         var x5c = new CborArray { attestnCert.RawData, root.RawData };
 
-        byte[] signature = SignData(type, alg, COSE.EllipticCurve.Reserved, ecdsa: ecdsaAtt);
+        byte[] signature = SignData(type, alg, COSE.EllipticCurve.P256, ecdsa: ecdsaAtt);
 
         _attestationObject.Add("attStmt", new CborMap {
             { "alg", alg },

--- a/Tests/Fido2.Tests/CredentialPublicKeyTests.cs
+++ b/Tests/Fido2.Tests/CredentialPublicKeyTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Security.Cryptography;
-
+using System.Security.Cryptography.X509Certificates;
 using Fido2NetLib;
 using Fido2NetLib.Objects;
 
@@ -40,8 +40,22 @@ public class CredentialPublicKeyTests
             Assert.Equal(oid, decodedEcDsaParams.Curve.Oid.Value);
         }
 
-
-
         Assert.True(credentialPublicKey.Verify(signedData, signature));
+    }
+
+    [Theory]
+    [InlineData("A501020326200121581F6F56E6590BD91D39744F83A820E8B3FBB6608DA583794091538296D1DA73E2225820B0A65E0B18D3189DA3B4A7036202ADF65A6B68EFF8C24825532D7A04386AE628", 0x80131501)]
+    public void InvalidCoseKey(string str, uint hresult)
+    {
+        var cpkBytes = Convert.FromHexString(str);
+        var ex = Assert.Throws<CryptographicException>(() => new CredentialPublicKey(cpkBytes));
+        Assert.True(((uint)ex.HResult) == hresult);
+    }
+
+    [Fact]
+    public void OkpCertificate()
+    {
+        X509Certificate2 okpCert = new(X509CertificateHelper.CreateFromBase64String("MIIBhTCCATegAwIBAgIUfKk9eVV+OkGNxxguVYluGHPPI+swBQYDK2VwMDgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhGbG9yaWRzYTEWMBQGA1UECgwNRklETzItTkVULUxJQjAeFw0yNDExMDQwMDM3MDNaFw0yNDEyMDQwMDM3MDNaMDgxCzAJBgNVBAYTAlVTMREwDwYDVQQIDAhGbG9yaWRzYTEWMBQGA1UECgwNRklETzItTkVULUxJQjAqMAUGAytlcAMhAJ2oFxsqEgM4DiMSJNskAYoKf55FXZhrde4Ho2UMJoKuo1MwUTAdBgNVHQ4EFgQUyhKwoqOmiB3UeXztoIPueEi7qSgwHwYDVR0jBBgwFoAUyhKwoqOmiB3UeXztoIPueEi7qSgwDwYDVR0TAQH/BAUwAwEB/zAFBgMrZXADQQArZ82PaihKfiOHNDPCmax/vgsuMlJcQsAywcQFZfaRiNyU5Cq7hwOvNlA1wl1j9hZjV/SiPsfNSgY7nwTGf9cE"u8));
+        CredentialPublicKey cpk = new(okpCert, COSE.Algorithm.EdDSA);
     }
 }


### PR DESCRIPTION
Add test for invalid COSE key types
Add support for OKP certificates for CredentialPublicKey and test for same
Fix two packed tests that erroneously used "Reserved" key type instead of P256

Closes #552