### PR TITLE
Wildcard orgin url feature

### DIFF
--- a/Src/Fido2.Models/StringExtensions.cs
+++ b/Src/Fido2.Models/StringExtensions.cs
@@ -1,14 +1,51 @@
-﻿namespace Fido2NetLib;
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
-public static class StringExtensions
+namespace Fido2NetLib
 {
-    public static string ToFullyQualifiedOrigin(this string origin)
+    public static class StringExtensions
     {
-        var uri = new Uri(origin);
+        public static string ToFullyQualifiedOrigin(this string origin)
+        {
+            if (IsWildCardUrl(origin))
+            {
+                var uri = new Uri(origin.Remove(origin.IndexOf("*."), 2));
+                if (UriHostNameType.Unknown != uri.HostNameType)
+                    return uri.IsDefaultPort ? $"{uri.Scheme}://*.{uri.Host}" : $"{uri.Scheme}://*.{uri.Host}:{uri.Port}";
+            }
+            else
+            {
+                var uri = new Uri(origin);
+                if (UriHostNameType.Unknown != uri.HostNameType)
+                    return uri.IsDefaultPort ? $"{uri.Scheme}://{uri.Host}" : $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            }
 
-        if (UriHostNameType.Unknown != uri.HostNameType)
-            return uri.IsDefaultPort ? $"{uri.Scheme}://{uri.Host}" : $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+            return origin;
+        }
 
-        return origin;
+        public static bool ContainsUrl(this IReadOnlySet<string> fullyQualifiedExpectedOrigins, string fullyQualifiedOrigin)
+        {
+            foreach (var fullyQualifiedExpectedOrigin in fullyQualifiedExpectedOrigins)
+            {
+                if ((IsWildCardUrl(fullyQualifiedExpectedOrigin) && IsMatch(fullyQualifiedExpectedOrigin, fullyQualifiedOrigin)) || (fullyQualifiedExpectedOrigin.Equals(fullyQualifiedOrigin, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool IsWildCardUrl(string origin)
+        {
+            string pattern = @"^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/\*\..*$";
+            return Regex.IsMatch(origin, pattern);
+        }
+
+        private static bool IsMatch(string wildcardUrl, string testUrl)
+        {
+            var pattern = "^" + Regex.Escape(wildcardUrl).Replace("\\*", "[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?") + "$";
+            return Regex.IsMatch(testUrl, pattern);
+        }
     }
 }

--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -82,7 +82,7 @@ public class AuthenticatorResponse
         var fullyQualifiedOrigin = Origin.ToFullyQualifiedOrigin();
 
         // 12. Verify that the value of C.origin matches the Relying Party's origin.
-        if (!fullyQualifiedExpectedOrigins.Contains(fullyQualifiedOrigin))
+        if (!fullyQualifiedExpectedOrigins.ContainsUrl(fullyQualifiedOrigin))
             throw new Fido2VerificationException($"Fully qualified origin {fullyQualifiedOrigin} of {Origin} not equal to fully qualified original origin {string.Join(", ", fullyQualifiedExpectedOrigins.Take(MAX_ORIGINS_TO_PRINT))} ({fullyQualifiedExpectedOrigins.Count})");
 
         // 13?. Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over which the assertion was obtained.


### PR DESCRIPTION
This PR is regarding allowing fido passwordless flow from subdomain using wildcard url in origin 

so you can set origin to https://*.example.com to accept all subdomains of example.com
Eg: https://sub.example.com
@abergs