### PR TITLE
Enable packing for Fido2.BlazorWebAssembly project

### DIFF
--- a/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
+++ b/Src/Fido2.BlazorWebAssembly/Fido2.BlazorWebAssembly.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsTrimmable>true</IsTrimmable>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Turns out, release 4.0.0 didn't include the WebAssembly package. Whoops.