### PR TITLE
feat(ci): Add Windows and macOS runners to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,9 +84,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Windows runners don't support Linux Docker containers (needed for tests),
-          # so we currently cannot run tests on Windows.
-          # - windows-latest
+          - windows-latest
+          - macos-latest
 
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
Adds support for running the CI tests on Windows and macOS
platforms in addition to the existing Ubuntu runner. This
ensures the application is compatible across a wider range
of operating systems.