### PR TITLE
Move the demo website to its own domain

### DIFF
--- a/Demo/Helpers/RouteHelperExtensions.cs
+++ b/Demo/Helpers/RouteHelperExtensions.cs
@@ -17,9 +17,9 @@ public static class RouteHelperExtensions
         public virtual void ApplyRule(RewriteContext context)
         {
             var req = context.HttpContext.Request;
-            if (req.Host.Host is "passwordless.dev" or "fido2.azurewebsites.net")
+            if (req.Host.Host is "fido2.azurewebsites.net")
             {
-                var wwwHost = new HostString("www.passwordless.dev");
+                var wwwHost = new HostString("fido2.andersaberg.com");
                 var newUrl = UriHelper.BuildAbsolute("https", wwwHost, req.PathBase, req.Path, req.QueryString);
                 var response = context.HttpContext.Response;
                 response.StatusCode = 301;

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dotnet add package Fido2.BlazorWebAssembly
 
 ### Demo
 
-- **Library website**: https://fido2-net-lib.passwordless.dev
+- **Library website**: https://fido2.andersaberg.com
 - [Code examples](#examples)
 
 ## What is FIDO2?


### PR DESCRIPTION
This PR aligns with some DNS changes to move the demo website to it’s own domain.

This is to make sure we can deploy more frequently without disturbing Bitwarden related activities at the passwordless.dev domain.