### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,6 +183,7 @@ jobs:
     permissions:
       actions: read
       packages: write
+      id-token: write
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,10 +205,18 @@ jobs:
           --source https://nuget.pkg.github.com/passwordless-lib/index.json
           --api-key ${{ secrets.GITHUB_TOKEN }}
 
+      # Only login to NuGet on stable release
+      - name: NuGet login (NuGet Registry)
+        uses: NuGet/login@v1
+        if: ${{ github.event_name == 'release' || github.event.inputs.force_release }}
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       # Only publish to NuGet on stable releases
       - name: Publish packages (NuGet Registry)
         if: ${{ github.event_name == 'release' || github.event.inputs.force_release }}
         run: >
           dotnet nuget push **/*.nupkg
           --source https://api.nuget.org/v3/index.json
-          --api-key ${{ secrets.nuget_api_key }}
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (abergs in this case).  
- The old `secrets.NUGET_API_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `abergs`).  
   - **Repository owner:** your GitHub org/user (e.g. `passwordless-lib`).  
   - **Repository name:** repository name (e.g. `fido2-net-lib`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `main.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.