### PR TITLE
Handle malformed assertion signatures

### DIFF
--- a/Tests/Fido2.Tests/AuthenticatorResponse.cs
+++ b/Tests/Fido2.Tests/AuthenticatorResponse.cs
@@ -2461,8 +2461,12 @@ public class AuthenticatorResponseTests
         Assert.Equal(Fido2ErrorMessages.MissingStoredPublicKey, ex.Message);
     }
 
-    [Fact]
-    public async Task TestAuthenticatorAssertionInvalidSignature()
+    [Theory]
+    [InlineData(new byte[] { 0x30, 0x00 }, true)]
+    [InlineData(new byte[] { 0x30, 0x00 }, false)]
+    [InlineData(new byte[] { 0xf1, 0xd0 }, true)]
+    [InlineData(new byte[] { 0xf1, 0xd0 }, false)]
+    public async Task TestAuthenticatorAssertionInvalidSignature(byte[] signature, bool useEdDsa)
     {
         var challenge = RandomNumberGenerator.GetBytes(128);
         var rp = "https://www.passwordless.dev";
@@ -2488,7 +2492,7 @@ public class AuthenticatorResponseTests
         var assertion = new AuthenticatorAssertionRawResponse.AssertionResponse()
         {
             AuthenticatorData = new AuthenticatorData(SHA256.HashData(Encoding.UTF8.GetBytes(rp)), AuthenticatorFlags.UP | AuthenticatorFlags.UV, 0, null, new Extensions(new byte[] { 0x42 })).ToByteArray(),
-            Signature = [0xf1, 0xd0],
+            Signature = signature,
             ClientDataJson = clientDataJson,
             UserHandle = [0xf1, 0xd0],
         };
@@ -2526,12 +2530,23 @@ public class AuthenticatorResponseTests
             return Task.FromResult(true);
         };
 
-        fido2_net_lib.Test.Fido2Tests.MakeEdDSA(out _, out var publicKey, out var privateKey);
+        byte[] publicKeyBytes;
+        if (useEdDsa)
+        {
+            fido2_net_lib.Test.Fido2Tests.MakeEdDSA(out _, out var publicKey, out var privateKey);
+            publicKeyBytes = fido2_net_lib.Test.Fido2Tests.MakeCredentialPublicKey(COSE.KeyType.OKP, COSE.Algorithm.EdDSA, COSE.EllipticCurve.Ed25519, publicKey).GetBytes();
+        }
+        else
+        {
+            using var ecdsa = fido2_net_lib.Test.Fido2Tests.MakeECDsa(COSE.Algorithm.ES256, COSE.EllipticCurve.P256);
+            publicKeyBytes = new CredentialPublicKey(ecdsa, COSE.Algorithm.ES256).GetBytes();
+        }
+
         var ex = await Assert.ThrowsAsync<Fido2VerificationException>(() => lib.MakeAssertionAsync(new MakeAssertionParams
         {
             AssertionResponse = assertionResponse,
             OriginalOptions = options,
-            StoredPublicKey = fido2_net_lib.Test.Fido2Tests.MakeCredentialPublicKey(COSE.KeyType.OKP, COSE.Algorithm.EdDSA, COSE.EllipticCurve.Ed25519, publicKey).GetBytes(),
+            StoredPublicKey = publicKeyBytes,
             StoredSignatureCounter = 0,
             IsUserHandleOwnerOfCredentialIdCallback = callback
         }));


### PR DESCRIPTION
So far this PR is only the unit tests that illustrate what (I think) is a problem, and I am interested in feedback before I attempt the fix.

My expectation was that any type of invalid signature, regardless of how malformed it was, would throw the `Fido2VerificationException` with message "Signature does not match". But, as illustrated by these unit tests, some signatures throw other exceptions:

```
Assert.Throws() Failure: Exception type was not an exact match
Expected: typeof(Fido2NetLib.Fido2VerificationException)
Actual:   typeof(System.Formats.Asn1.AsnContentException)
---- System.Formats.Asn1.AsnContentException : The ASN.1 value is invalid.
```

and 

```
 Assert.Throws() Failure: Exception type was not an exact match
 Expected: typeof(Fido2NetLib.Fido2VerificationException)
 Actual:   typeof(System.ArgumentOutOfRangeException)
 ---- System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
```

Should the `VerifyAsync` method trap these exceptions or should the underlying `CryptoUtils.SigFromEcDsaSig` throw a `Fido2VerificationException`? I see that another method in that file, `HashAlgFromCOSEAlg`, _does_ throw a `Fido2VerificationException`.
